### PR TITLE
Fix null return values for LangChain4j compatibility

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -29,10 +29,11 @@ async def list_available_accounts() -> list[AccountAttributes]:
 
 
 @mcp.tool(description="Add a new email account configuration to the settings.")
-async def add_email_account(email: EmailSettings) -> None:
+async def add_email_account(email: EmailSettings) -> str:
     settings = get_settings()
     settings.add_email(email)
     settings.store()
+    return f"Successfully added email account '{email.account_name}'"
 
 
 @mcp.tool(description="Paginate emails, page start at 1, before and since as UTC datetime.")
@@ -96,7 +97,8 @@ async def send_email(
         list[str] | None,
         Field(default=None, description="A list of BCC email addresses."),
     ] = None,
-) -> None:
+) -> str:
     handler = dispatch_handler(account_name)
     await handler.send_email(recipients, subject, body, cc, bcc)
-    return
+    recipient_str = ", ".join(recipients)
+    return f"Email sent successfully to {recipient_str}"

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -89,7 +89,10 @@ class TestMcpTools:
 
         with patch("mcp_email_server.app.get_settings", return_value=mock_settings):
             # Call the function
-            await add_email_account(email_settings)
+            result = await add_email_account(email_settings)
+
+            # Verify the return value
+            assert result == "Successfully added email account 'test_account'"
 
             # Verify add_email and store were called correctly
             mock_settings.add_email.assert_called_once_with(email_settings)
@@ -170,7 +173,7 @@ class TestMcpTools:
 
         with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
             # Call the function
-            await send_email(
+            result = await send_email(
                 account_name="test_account",
                 recipients=["recipient@example.com"],
                 subject="Test Subject",
@@ -178,6 +181,9 @@ class TestMcpTools:
                 cc=["cc@example.com"],
                 bcc=["bcc@example.com"],
             )
+
+            # Verify the return value
+            assert result == "Email sent successfully to recipient@example.com"
 
             # Verify send_email was called correctly
             mock_handler.send_email.assert_called_once_with(


### PR DESCRIPTION
- send_email now returns success message instead of None
- add_email_account now returns success message instead of None  
- Updated tests to verify return values
- Fixes #42

This PR replaces #44 which had merge conflicts.