### PR TITLE
feat: refactor email models and handlers - separate metadata from content

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -11,7 +11,7 @@ from mcp_email_server.config import (
     get_settings,
 )
 from mcp_email_server.emails.dispatcher import dispatch_handler
-from mcp_email_server.emails.models import EmailPageResponse
+from mcp_email_server.emails.models import EmailMetadataPageResponse, EmailContentBatchResponse
 
 mcp = FastMCP("email")
 
@@ -36,8 +36,8 @@ async def add_email_account(email: EmailSettings) -> str:
     return f"Successfully added email account '{email.account_name}'"
 
 
-@mcp.tool(description="Paginate emails, page start at 1, before and since as UTC datetime.")
-async def page_email(
+@mcp.tool(description="List email metadata (email_id, subject, sender, recipients, date) without body content. Returns email_id for use with get_emails_content.")
+async def list_emails_metadata(
     account_name: Annotated[str, Field(description="The name of the email account.")],
     page: Annotated[
         int,
@@ -53,8 +53,6 @@ async def page_email(
         Field(default=None, description="Retrieve emails since this datetime (UTC)."),
     ] = None,
     subject: Annotated[str | None, Field(default=None, description="Filter emails by subject.")] = None,
-    body: Annotated[str | None, Field(default=None, description="Filter emails by body.")] = None,
-    text: Annotated[str | None, Field(default=None, description="Filter emails by text.")] = None,
     from_address: Annotated[str | None, Field(default=None, description="Filter emails by sender address.")] = None,
     to_address: Annotated[
         str | None,
@@ -64,22 +62,28 @@ async def page_email(
         Literal["asc", "desc"],
         Field(default=None, description="Order emails by field. `asc` or `desc`."),
     ] = "desc",
-) -> EmailPageResponse:
+) -> EmailMetadataPageResponse:
     handler = dispatch_handler(account_name)
 
-    return await handler.get_emails(
+    return await handler.get_emails_metadata(
         page=page,
         page_size=page_size,
         before=before,
         since=since,
         subject=subject,
-        body=body,
-        text=text,
         from_address=from_address,
         to_address=to_address,
         order=order,
     )
 
+
+@mcp.tool(description="Get the full content (including body) of one or more emails by their email_id. Use list_emails_metadata first to get the email_id.")
+async def get_emails_content(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    email_ids: Annotated[list[str], Field(description="List of email_id to retrieve (obtained from list_emails_metadata). Can be a single email_id or multiple email_ids.")],
+) -> EmailContentBatchResponse:
+    handler = dispatch_handler(account_name)
+    return await handler.get_emails_content(email_ids)
 
 @mcp.tool(
     description="Send an email using the specified account. Recipient should be a list of email addresses.",

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -11,7 +11,7 @@ from mcp_email_server.config import (
     get_settings,
 )
 from mcp_email_server.emails.dispatcher import dispatch_handler
-from mcp_email_server.emails.models import EmailMetadataPageResponse, EmailContentBatchResponse
+from mcp_email_server.emails.models import EmailContentBatchResponse, EmailMetadataPageResponse
 
 mcp = FastMCP("email")
 
@@ -36,7 +36,9 @@ async def add_email_account(email: EmailSettings) -> str:
     return f"Successfully added email account '{email.account_name}'"
 
 
-@mcp.tool(description="List email metadata (email_id, subject, sender, recipients, date) without body content. Returns email_id for use with get_emails_content.")
+@mcp.tool(
+    description="List email metadata (email_id, subject, sender, recipients, date) without body content. Returns email_id for use with get_emails_content."
+)
 async def list_emails_metadata(
     account_name: Annotated[str, Field(description="The name of the email account.")],
     page: Annotated[
@@ -77,13 +79,21 @@ async def list_emails_metadata(
     )
 
 
-@mcp.tool(description="Get the full content (including body) of one or more emails by their email_id. Use list_emails_metadata first to get the email_id.")
+@mcp.tool(
+    description="Get the full content (including body) of one or more emails by their email_id. Use list_emails_metadata first to get the email_id."
+)
 async def get_emails_content(
     account_name: Annotated[str, Field(description="The name of the email account.")],
-    email_ids: Annotated[list[str], Field(description="List of email_id to retrieve (obtained from list_emails_metadata). Can be a single email_id or multiple email_ids.")],
+    email_ids: Annotated[
+        list[str],
+        Field(
+            description="List of email_id to retrieve (obtained from list_emails_metadata). Can be a single email_id or multiple email_ids."
+        ),
+    ],
 ) -> EmailContentBatchResponse:
     handler = dispatch_handler(account_name)
     return await handler.get_emails_content(email_ids)
+
 
 @mcp.tool(
     description="Send an email using the specified account. Recipient should be a list of email addresses.",

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -3,26 +3,30 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from mcp_email_server.emails.models import EmailPageResponse
+    from mcp_email_server.emails.models import EmailMetadataPageResponse, EmailContentBatchResponse
 
 
 class EmailHandler(abc.ABC):
     @abc.abstractmethod
-    async def get_emails(
+    async def get_emails_metadata(
         self,
         page: int = 1,
         page_size: int = 10,
         before: datetime | None = None,
-        after: datetime | None = None,
+        since: datetime | None = None,
         subject: str | None = None,
-        body: str | None = None,
-        text: str | None = None,
         from_address: str | None = None,
         to_address: str | None = None,
         order: str = "desc",
-    ) -> "EmailPageResponse":
+    ) -> "EmailMetadataPageResponse":
         """
-        Get emails
+        Get email metadata only (without body content) for better performance
+        """
+
+    @abc.abstractmethod
+    async def get_emails_content(self, email_ids: list[str]) -> "EmailContentBatchResponse":
+        """
+        Get full content (including body) of multiple emails by their email IDs (IMAP UIDs)
         """
 
     @abc.abstractmethod

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from mcp_email_server.emails.models import EmailMetadataPageResponse, EmailContentBatchResponse
+    from mcp_email_server.emails.models import EmailContentBatchResponse, EmailMetadataPageResponse
 
 
 class EmailHandler(abc.ABC):

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -12,7 +12,7 @@ import aiosmtplib
 
 from mcp_email_server.config import EmailServer, EmailSettings
 from mcp_email_server.emails import EmailHandler
-from mcp_email_server.emails.models import EmailData, EmailPageResponse
+from mcp_email_server.emails.models import EmailMetadata, EmailMetadataPageResponse, EmailBodyResponse, EmailContentBatchResponse
 from mcp_email_server.log import logger
 
 
@@ -26,7 +26,7 @@ class EmailClient:
         self.smtp_use_tls = self.email_server.use_ssl
         self.smtp_start_tls = self.email_server.start_ssl
 
-    def _parse_email_data(self, raw_email: bytes) -> dict[str, Any]:  # noqa: C901
+    def _parse_email_data(self, raw_email: bytes, email_id: str | None = None) -> dict[str, Any]:  # noqa: C901
         """Parse raw email data into a structured dictionary."""
         parser = BytesParser(policy=default)
         email_message = parser.parsebytes(raw_email)
@@ -35,6 +35,18 @@ class EmailClient:
         subject = email_message.get("Subject", "")
         sender = email_message.get("From", "")
         date_str = email_message.get("Date", "")
+        
+        # Extract recipients
+        to_addresses = []
+        to_header = email_message.get("To", "")
+        if to_header:
+            # Simple parsing - split by comma and strip whitespace
+            to_addresses = [addr.strip() for addr in to_header.split(",")]
+        
+        # Also check CC recipients
+        cc_header = email_message.get("Cc", "")
+        if cc_header:
+            to_addresses.extend([addr.strip() for addr in cc_header.split(",")])
 
         # Parse date
         try:
@@ -77,137 +89,15 @@ class EmailClient:
                     body = payload.decode("utf-8", errors="replace")
 
         return {
+            "email_id": email_id or "",
             "subject": subject,
             "from": sender,
+            "to": to_addresses,
             "body": body,
             "date": date,
             "attachments": attachments,
         }
 
-    async def get_emails_stream(  # noqa: C901
-        self,
-        page: int = 1,
-        page_size: int = 10,
-        before: datetime | None = None,
-        since: datetime | None = None,
-        subject: str | None = None,
-        body: str | None = None,
-        text: str | None = None,
-        from_address: str | None = None,
-        to_address: str | None = None,
-        order: str = "desc",
-    ) -> AsyncGenerator[dict[str, Any], None]:
-        imap = self.imap_class(self.email_server.host, self.email_server.port)
-        try:
-            # Wait for the connection to be established
-            await imap._client_task
-            await imap.wait_hello_from_server()
-
-            # Login and select inbox
-            await imap.login(self.email_server.user_name, self.email_server.password)
-            try:
-                await imap.id(name="mcp-email-server", version="1.0.0")
-            except Exception as e:
-                logger.warning(f"IMAP ID command failed: {e!s}")
-            await imap.select("INBOX")
-
-            search_criteria = self._build_search_criteria(before, since, subject, body, text, from_address, to_address)
-            logger.info(f"Get: Search criteria: {search_criteria}")
-
-            # Search for messages - use UID SEARCH for better compatibility
-            _, messages = await imap.uid_search(*search_criteria)
-
-            # Handle empty or None responses
-            if not messages or not messages[0]:
-                logger.warning("No messages returned from search")
-                message_ids = []
-            else:
-                message_ids = messages[0].split()
-                logger.info(f"Found {len(message_ids)} message IDs")
-            start = (page - 1) * page_size
-            end = start + page_size
-
-            if order == "desc":
-                message_ids.reverse()
-
-            # Fetch each message
-            for _, message_id in enumerate(message_ids[start:end]):
-                try:
-                    # Convert message_id from bytes to string
-                    message_id_str = message_id.decode("utf-8")
-
-                    # Fetch the email using UID - try different formats for compatibility
-                    data = None
-                    fetch_formats = ["RFC822", "BODY[]", "BODY.PEEK[]", "(BODY.PEEK[])"]
-
-                    for fetch_format in fetch_formats:
-                        try:
-                            _, data = await imap.uid("fetch", message_id_str, fetch_format)
-
-                            if data and len(data) > 0:
-                                # Check if we got actual email content or just metadata
-                                has_content = False
-                                for item in data:
-                                    if (
-                                        isinstance(item, bytes)
-                                        and b"FETCH (" in item
-                                        and b"RFC822" not in item
-                                        and b"BODY" not in item
-                                    ):
-                                        # This is just metadata (like 'FETCH (UID 71998)'), not actual content
-                                        continue
-                                    elif isinstance(item, bytes | bytearray) and len(item) > 100:
-                                        # This looks like email content
-                                        has_content = True
-                                        break
-
-                                if has_content:
-                                    break
-                                else:
-                                    data = None  # Try next format
-
-                        except Exception as e:
-                            logger.debug(f"Fetch format {fetch_format} failed: {e}")
-                            data = None
-
-                    if not data:
-                        logger.error(f"Failed to fetch UID {message_id_str} with any format")
-                        continue
-
-                    # Find the email data in the response
-                    raw_email = None
-
-                    # The email content is typically at index 1 as a bytearray
-                    if len(data) > 1 and isinstance(data[1], bytearray):
-                        raw_email = bytes(data[1])
-                    else:
-                        # Search through all items for email content
-                        for item in data:
-                            if isinstance(item, bytes | bytearray) and len(item) > 100:
-                                # Skip IMAP protocol responses
-                                if isinstance(item, bytes) and b"FETCH" in item:
-                                    continue
-                                # This is likely the email content
-                                raw_email = bytes(item) if isinstance(item, bytearray) else item
-                                break
-
-                    if raw_email:
-                        try:
-                            parsed_email = self._parse_email_data(raw_email)
-                            yield parsed_email
-                        except Exception as e:
-                            # Log error but continue with other emails
-                            logger.error(f"Error parsing email: {e!s}")
-                    else:
-                        logger.error(f"Could not find email data in response for message ID: {message_id_str}")
-                except Exception as e:
-                    logger.error(f"Error fetching message {message_id}: {e!s}")
-        finally:
-            # Ensure we logout properly
-            try:
-                await imap.logout()
-            except Exception as e:
-                logger.info(f"Error during logout: {e}")
 
     @staticmethod
     def _build_search_criteria(
@@ -260,11 +150,223 @@ class EmailClient:
             # Login and select inbox
             await imap.login(self.email_server.user_name, self.email_server.password)
             await imap.select("INBOX")
-            search_criteria = self._build_search_criteria(before, since, subject, body, text, from_address, to_address)
+            search_criteria = self._build_search_criteria(before, since, subject, from_address=from_address, to_address=to_address)
             logger.info(f"Count: Search criteria: {search_criteria}")
             # Search for messages and count them - use UID SEARCH for consistency
             _, messages = await imap.uid_search(*search_criteria)
             return len(messages[0].split())
+        finally:
+            # Ensure we logout properly
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
+    async def get_emails_metadata_stream(  # noqa: C901
+        self,
+        page: int = 1,
+        page_size: int = 10,
+        before: datetime | None = None,
+        since: datetime | None = None,
+        subject: str | None = None,
+        from_address: str | None = None,
+        to_address: str | None = None,
+        order: str = "desc",
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        imap = self.imap_class(self.email_server.host, self.email_server.port)
+        try:
+            # Wait for the connection to be established
+            await imap._client_task
+            await imap.wait_hello_from_server()
+
+            # Login and select inbox
+            await imap.login(self.email_server.user_name, self.email_server.password)
+            try:
+                await imap.id(name="mcp-email-server", version="1.0.0")
+            except Exception as e:
+                logger.warning(f"IMAP ID command failed: {e!s}")
+            await imap.select("INBOX")
+
+            search_criteria = self._build_search_criteria(before, since, subject, from_address=from_address, to_address=to_address)
+            logger.info(f"Get metadata: Search criteria: {search_criteria}")
+
+            # Search for messages - use UID SEARCH for better compatibility
+            _, messages = await imap.uid_search(*search_criteria)
+
+            # Handle empty or None responses
+            if not messages or not messages[0]:
+                logger.warning("No messages returned from search")
+                email_ids = []
+            else:
+                email_ids = messages[0].split()
+                logger.info(f"Found {len(email_ids)} email IDs")
+            start = (page - 1) * page_size
+            end = start + page_size
+
+            if order == "desc":
+                email_ids.reverse()
+
+            # Fetch each message's metadata only
+            for _, email_id in enumerate(email_ids[start:end]):
+                try:
+                    # Convert email_id from bytes to string
+                    email_id_str = email_id.decode("utf-8")
+
+                    # Fetch only headers to get metadata without body
+                    _, data = await imap.uid("fetch", email_id_str, "BODY.PEEK[HEADER]")
+
+                    if not data:
+                        logger.error(f"Failed to fetch headers for UID {email_id_str}")
+                        continue
+
+                    # Find the email headers in the response
+                    raw_headers = None
+                    if len(data) > 1 and isinstance(data[1], bytearray):
+                        raw_headers = bytes(data[1])
+                    else:
+                        # Search through all items for header content
+                        for item in data:
+                            if isinstance(item, bytes | bytearray) and len(item) > 10:
+                                # Skip IMAP protocol responses
+                                if isinstance(item, bytes) and b"FETCH" in item:
+                                    continue
+                                # This is likely the header content
+                                raw_headers = bytes(item) if isinstance(item, bytearray) else item
+                                break
+
+                    if raw_headers:
+                        try:
+                            # Parse headers only
+                            parser = BytesParser(policy=default)
+                            email_message = parser.parsebytes(raw_headers)
+
+                            # Extract metadata
+                            subject = email_message.get("Subject", "")
+                            sender = email_message.get("From", "")
+                            date_str = email_message.get("Date", "")
+                            
+                            # Extract recipients
+                            to_addresses = []
+                            to_header = email_message.get("To", "")
+                            if to_header:
+                                to_addresses = [addr.strip() for addr in to_header.split(",")]
+                            
+                            cc_header = email_message.get("Cc", "")
+                            if cc_header:
+                                to_addresses.extend([addr.strip() for addr in cc_header.split(",")])
+
+                            # Parse date
+                            try:
+                                date_tuple = email.utils.parsedate_tz(date_str)
+                                date = datetime.fromtimestamp(email.utils.mktime_tz(date_tuple)) if date_tuple else datetime.now()
+                            except Exception:
+                                date = datetime.now()
+
+                            # For metadata, we don't fetch attachments to save bandwidth
+                            # We'll mark it as unknown for now
+                            metadata = {
+                                "email_id": email_id_str,
+                                "subject": subject,
+                                "from": sender,
+                                "to": to_addresses,
+                                "date": date,
+                                "attachments": [],  # We don't fetch attachment info for metadata
+                            }
+                            yield metadata
+                        except Exception as e:
+                            # Log error but continue with other emails
+                            logger.error(f"Error parsing email metadata: {e!s}")
+                    else:
+                        logger.error(f"Could not find header data in response for email ID: {email_id_str}")
+                except Exception as e:
+                    logger.error(f"Error fetching email metadata {email_id}: {e!s}")
+        finally:
+            # Ensure we logout properly
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
+    async def get_email_body_by_id(self, email_id: str) -> dict[str, Any] | None:
+        imap = self.imap_class(self.email_server.host, self.email_server.port)
+        try:
+            # Wait for the connection to be established
+            await imap._client_task
+            await imap.wait_hello_from_server()
+
+            # Login and select inbox
+            await imap.login(self.email_server.user_name, self.email_server.password)
+            try:
+                await imap.id(name="mcp-email-server", version="1.0.0")
+            except Exception as e:
+                logger.warning(f"IMAP ID command failed: {e!s}")
+            await imap.select("INBOX")
+
+            # Fetch the specific email by UID
+            data = None
+            fetch_formats = ["RFC822", "BODY[]", "BODY.PEEK[]", "(BODY.PEEK[])"]
+
+            for fetch_format in fetch_formats:
+                try:
+                    _, data = await imap.uid("fetch", email_id, fetch_format)
+
+                    if data and len(data) > 0:
+                        # Check if we got actual email content or just metadata
+                        has_content = False
+                        for item in data:
+                            if (
+                                isinstance(item, bytes)
+                                and b"FETCH (" in item
+                                and b"RFC822" not in item
+                                and b"BODY" not in item
+                            ):
+                                # This is just metadata, not actual content
+                                continue
+                            elif isinstance(item, bytes | bytearray) and len(item) > 100:
+                                # This looks like email content
+                                has_content = True
+                                break
+
+                        if has_content:
+                            break
+                        else:
+                            data = None  # Try next format
+
+                except Exception as e:
+                    logger.debug(f"Fetch format {fetch_format} failed: {e}")
+                    data = None
+
+            if not data:
+                logger.error(f"Failed to fetch UID {email_id} with any format")
+                return None
+
+            # Find the email data in the response
+            raw_email = None
+
+            # The email content is typically at index 1 as a bytearray
+            if len(data) > 1 and isinstance(data[1], bytearray):
+                raw_email = bytes(data[1])
+            else:
+                # Search through all items for email content
+                for item in data:
+                    if isinstance(item, bytes | bytearray) and len(item) > 100:
+                        # Skip IMAP protocol responses
+                        if isinstance(item, bytes) and b"FETCH" in item:
+                            continue
+                        # This is likely the email content
+                        raw_email = bytes(item) if isinstance(item, bytearray) else item
+                        break
+
+            if raw_email:
+                try:
+                    return self._parse_email_data(raw_email, email_id)
+                except Exception as e:
+                    logger.error(f"Error parsing email: {e!s}")
+                    return None
+            else:
+                logger.error(f"Could not find email data in response for email ID: {email_id}")
+                return None
+
         finally:
             # Ensure we logout properly
             try:
@@ -326,35 +428,63 @@ class ClassicEmailHandler(EmailHandler):
             sender=f"{email_settings.full_name} <{email_settings.email_address}>",
         )
 
-    async def get_emails(
+
+    async def get_emails_metadata(
         self,
         page: int = 1,
         page_size: int = 10,
         before: datetime | None = None,
         since: datetime | None = None,
         subject: str | None = None,
-        body: str | None = None,
-        text: str | None = None,
         from_address: str | None = None,
         to_address: str | None = None,
         order: str = "desc",
-    ) -> EmailPageResponse:
+    ) -> EmailMetadataPageResponse:
         emails = []
-        async for email_data in self.incoming_client.get_emails_stream(
-            page, page_size, before, since, subject, body, text, from_address, to_address, order
+        async for email_data in self.incoming_client.get_emails_metadata_stream(
+            page, page_size, before, since, subject, from_address, to_address, order
         ):
-            emails.append(EmailData.from_email(email_data))
-        total = await self.incoming_client.get_email_count(before, since, subject, body, text, from_address, to_address)
-        return EmailPageResponse(
+            emails.append(EmailMetadata.from_email(email_data))
+        total = await self.incoming_client.get_email_count(before, since, subject, from_address=from_address, to_address=to_address)
+        return EmailMetadataPageResponse(
             page=page,
             page_size=page_size,
             before=before,
             since=since,
             subject=subject,
-            body=body,
-            text=text,
             emails=emails,
             total=total,
+        )
+
+    async def get_emails_content(self, email_ids: list[str]) -> EmailContentBatchResponse:
+        """批量获取邮件正文内容"""
+        emails = []
+        failed_ids = []
+        
+        for email_id in email_ids:
+            try:
+                email_data = await self.incoming_client.get_email_body_by_id(email_id)
+                if email_data:
+                    emails.append(EmailBodyResponse(
+                        email_id=email_data["email_id"],
+                        subject=email_data["subject"],
+                        sender=email_data["from"],
+                        recipients=email_data["to"],
+                        date=email_data["date"],
+                        body=email_data["body"],
+                        attachments=email_data["attachments"],
+                    ))
+                else:
+                    failed_ids.append(email_id)
+            except Exception as e:
+                logger.error(f"Failed to retrieve email {email_id}: {e}")
+                failed_ids.append(email_id)
+        
+        return EmailContentBatchResponse(
+            emails=emails,
+            requested_count=len(email_ids),
+            retrieved_count=len(emails),
+            failed_ids=failed_ids,
         )
 
     async def send_email(

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -12,7 +12,12 @@ import aiosmtplib
 
 from mcp_email_server.config import EmailServer, EmailSettings
 from mcp_email_server.emails import EmailHandler
-from mcp_email_server.emails.models import EmailMetadata, EmailMetadataPageResponse, EmailBodyResponse, EmailContentBatchResponse
+from mcp_email_server.emails.models import (
+    EmailBodyResponse,
+    EmailContentBatchResponse,
+    EmailMetadata,
+    EmailMetadataPageResponse,
+)
 from mcp_email_server.log import logger
 
 
@@ -35,14 +40,14 @@ class EmailClient:
         subject = email_message.get("Subject", "")
         sender = email_message.get("From", "")
         date_str = email_message.get("Date", "")
-        
+
         # Extract recipients
         to_addresses = []
         to_header = email_message.get("To", "")
         if to_header:
             # Simple parsing - split by comma and strip whitespace
             to_addresses = [addr.strip() for addr in to_header.split(",")]
-        
+
         # Also check CC recipients
         cc_header = email_message.get("Cc", "")
         if cc_header:
@@ -98,7 +103,6 @@ class EmailClient:
             "attachments": attachments,
         }
 
-
     @staticmethod
     def _build_search_criteria(
         before: datetime | None = None,
@@ -150,7 +154,9 @@ class EmailClient:
             # Login and select inbox
             await imap.login(self.email_server.user_name, self.email_server.password)
             await imap.select("INBOX")
-            search_criteria = self._build_search_criteria(before, since, subject, from_address=from_address, to_address=to_address)
+            search_criteria = self._build_search_criteria(
+                before, since, subject, from_address=from_address, to_address=to_address
+            )
             logger.info(f"Count: Search criteria: {search_criteria}")
             # Search for messages and count them - use UID SEARCH for consistency
             _, messages = await imap.uid_search(*search_criteria)
@@ -187,7 +193,9 @@ class EmailClient:
                 logger.warning(f"IMAP ID command failed: {e!s}")
             await imap.select("INBOX")
 
-            search_criteria = self._build_search_criteria(before, since, subject, from_address=from_address, to_address=to_address)
+            search_criteria = self._build_search_criteria(
+                before, since, subject, from_address=from_address, to_address=to_address
+            )
             logger.info(f"Get metadata: Search criteria: {search_criteria}")
 
             # Search for messages - use UID SEARCH for better compatibility
@@ -244,13 +252,13 @@ class EmailClient:
                             subject = email_message.get("Subject", "")
                             sender = email_message.get("From", "")
                             date_str = email_message.get("Date", "")
-                            
+
                             # Extract recipients
                             to_addresses = []
                             to_header = email_message.get("To", "")
                             if to_header:
                                 to_addresses = [addr.strip() for addr in to_header.split(",")]
-                            
+
                             cc_header = email_message.get("Cc", "")
                             if cc_header:
                                 to_addresses.extend([addr.strip() for addr in cc_header.split(",")])
@@ -258,7 +266,11 @@ class EmailClient:
                             # Parse date
                             try:
                                 date_tuple = email.utils.parsedate_tz(date_str)
-                                date = datetime.fromtimestamp(email.utils.mktime_tz(date_tuple)) if date_tuple else datetime.now()
+                                date = (
+                                    datetime.fromtimestamp(email.utils.mktime_tz(date_tuple))
+                                    if date_tuple
+                                    else datetime.now()
+                                )
                             except Exception:
                                 date = datetime.now()
 
@@ -428,7 +440,6 @@ class ClassicEmailHandler(EmailHandler):
             sender=f"{email_settings.full_name} <{email_settings.email_address}>",
         )
 
-
     async def get_emails_metadata(
         self,
         page: int = 1,
@@ -445,7 +456,9 @@ class ClassicEmailHandler(EmailHandler):
             page, page_size, before, since, subject, from_address, to_address, order
         ):
             emails.append(EmailMetadata.from_email(email_data))
-        total = await self.incoming_client.get_email_count(before, since, subject, from_address=from_address, to_address=to_address)
+        total = await self.incoming_client.get_email_count(
+            before, since, subject, from_address=from_address, to_address=to_address
+        )
         return EmailMetadataPageResponse(
             page=page,
             page_size=page_size,
@@ -460,26 +473,28 @@ class ClassicEmailHandler(EmailHandler):
         """批量获取邮件正文内容"""
         emails = []
         failed_ids = []
-        
+
         for email_id in email_ids:
             try:
                 email_data = await self.incoming_client.get_email_body_by_id(email_id)
                 if email_data:
-                    emails.append(EmailBodyResponse(
-                        email_id=email_data["email_id"],
-                        subject=email_data["subject"],
-                        sender=email_data["from"],
-                        recipients=email_data["to"],
-                        date=email_data["date"],
-                        body=email_data["body"],
-                        attachments=email_data["attachments"],
-                    ))
+                    emails.append(
+                        EmailBodyResponse(
+                            email_id=email_data["email_id"],
+                            subject=email_data["subject"],
+                            sender=email_data["from"],
+                            recipients=email_data["to"],
+                            date=email_data["date"],
+                            body=email_data["body"],
+                            attachments=email_data["attachments"],
+                        )
+                    )
                 else:
                     failed_ids.append(email_id)
             except Exception as e:
                 logger.error(f"Failed to retrieve email {email_id}: {e}")
                 failed_ids.append(email_id)
-        
+
         return EmailContentBatchResponse(
             emails=emails,
             requested_count=len(email_ids),

--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -6,7 +6,8 @@ from pydantic import BaseModel
 
 class EmailMetadata(BaseModel):
     """Email metadata"""
-    email_id: str  
+
+    email_id: str
     subject: str
     sender: str
     recipients: list[str]  # Recipient list
@@ -27,6 +28,7 @@ class EmailMetadata(BaseModel):
 
 class EmailMetadataPageResponse(BaseModel):
     """Paged email metadata response"""
+
     page: int
     page_size: int
     before: datetime | None
@@ -38,6 +40,7 @@ class EmailMetadataPageResponse(BaseModel):
 
 class EmailBodyResponse(BaseModel):
     """Single email body response"""
+
     email_id: str  # IMAP UID of this email
     subject: str
     sender: str
@@ -49,7 +52,8 @@ class EmailBodyResponse(BaseModel):
 
 class EmailContentBatchResponse(BaseModel):
     """Batch email content response for multiple emails"""
+
     emails: list[EmailBodyResponse]
     requested_count: int
     retrieved_count: int
-    failed_ids: list[str]  
+    failed_ids: list[str]

--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -4,31 +4,52 @@ from typing import Any
 from pydantic import BaseModel
 
 
-class EmailData(BaseModel):
+class EmailMetadata(BaseModel):
+    """Email metadata"""
+    email_id: str  
     subject: str
     sender: str
-    body: str
+    recipients: list[str]  # Recipient list
     date: datetime
     attachments: list[str]
 
     @classmethod
     def from_email(cls, email: dict[str, Any]):
         return cls(
+            email_id=email["email_id"],
             subject=email["subject"],
             sender=email["from"],
-            body=email["body"],
+            recipients=email.get("to", []),
             date=email["date"],
             attachments=email["attachments"],
         )
 
 
-class EmailPageResponse(BaseModel):
+class EmailMetadataPageResponse(BaseModel):
+    """Paged email metadata response"""
     page: int
     page_size: int
     before: datetime | None
     since: datetime | None
     subject: str | None
-    body: str | None
-    text: str | None
-    emails: list[EmailData]
+    emails: list[EmailMetadata]
     total: int
+
+
+class EmailBodyResponse(BaseModel):
+    """Single email body response"""
+    email_id: str  # IMAP UID of this email
+    subject: str
+    sender: str
+    recipients: list[str]
+    date: datetime
+    body: str
+    attachments: list[str]
+
+
+class EmailContentBatchResponse(BaseModel):
+    """Batch email content response for multiple emails"""
+    emails: list[EmailBodyResponse]
+    requested_count: int
+    retrieved_count: int
+    failed_ids: list[str]  

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
@@ -6,7 +5,7 @@ import pytest
 
 from mcp_email_server.config import EmailServer, EmailSettings
 from mcp_email_server.emails.classic import ClassicEmailHandler, EmailClient
-from mcp_email_server.emails.models import EmailMetadata, EmailMetadataPageResponse, EmailBodyResponse
+from mcp_email_server.emails.models import EmailMetadata, EmailMetadataPageResponse
 
 
 @pytest.fixture
@@ -105,7 +104,9 @@ class TestClassicEmailHandler:
                 classic_handler.incoming_client.get_emails_metadata_stream.assert_called_once_with(
                     1, 10, now, None, "Test", "sender@example.com", None, "desc"
                 )
-                mock_count.assert_called_once_with(now, None, "Test", from_address="sender@example.com", to_address=None)
+                mock_count.assert_called_once_with(
+                    now, None, "Test", from_address="sender@example.com", to_address=None
+                )
 
     @pytest.mark.asyncio
     async def test_send_email(self, classic_handler):

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -177,7 +177,7 @@ This is the email body."""
                 }
 
                 emails = []
-                async for email_data in email_client.get_emails_stream(page=1, page_size=10):
+                async for email_data in email_client.get_emails_metadata_stream(page=1, page_size=10):
                     emails.append(email_data)
 
                 # We should get 3 emails (from the mocked search result "1 2 3")

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -104,7 +104,6 @@ class TestMcpTools:
             mock_settings.add_email.assert_called_once_with(email_settings)
             mock_settings.store.assert_called_once()
 
-
     @pytest.mark.asyncio
     async def test_list_emails_metadata(self):
         """Test list_emails_metadata MCP tool."""
@@ -227,7 +226,7 @@ class TestMcpTools:
             body="This is the first test email body content.",
             attachments=[],
         )
-        
+
         email2 = EmailBodyResponse(
             email_id="12346",
             subject="Test Subject 2",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from mcp_email_server.emails.models import EmailMetadata, EmailMetadataPageResponse, EmailBodyResponse
+from mcp_email_server.emails.models import EmailMetadata, EmailMetadataPageResponse
 
 
 class TestEmailMetadata:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,22 +1,23 @@
 from datetime import datetime
 
-from mcp_email_server.emails.models import EmailData, EmailPageResponse
+from mcp_email_server.emails.models import EmailMetadata, EmailMetadataPageResponse, EmailBodyResponse
 
 
-class TestEmailData:
+class TestEmailMetadata:
     def test_init(self):
         """Test initialization with valid data."""
-        email_data = EmailData(
+        email_data = EmailMetadata(
+            email_id="123",
             subject="Test Subject",
             sender="test@example.com",
-            body="Test Body",
+            recipients=["recipient@example.com"],
             date=datetime.now(),
             attachments=["file1.txt", "file2.pdf"],
         )
 
         assert email_data.subject == "Test Subject"
         assert email_data.sender == "test@example.com"
-        assert email_data.body == "Test Body"
+        assert email_data.recipients == ["recipient@example.com"]
         assert isinstance(email_data.date, datetime)
         assert email_data.attachments == ["file1.txt", "file2.pdf"]
 
@@ -24,42 +25,42 @@ class TestEmailData:
         """Test from_email class method."""
         now = datetime.now()
         email_dict = {
+            "email_id": "123",
             "subject": "Test Subject",
             "from": "test@example.com",
-            "body": "Test Body",
+            "to": ["recipient@example.com"],
             "date": now,
             "attachments": ["file1.txt", "file2.pdf"],
         }
 
-        email_data = EmailData.from_email(email_dict)
+        email_data = EmailMetadata.from_email(email_dict)
 
         assert email_data.subject == "Test Subject"
         assert email_data.sender == "test@example.com"
-        assert email_data.body == "Test Body"
+        assert email_data.recipients == ["recipient@example.com"]
         assert email_data.date == now
         assert email_data.attachments == ["file1.txt", "file2.pdf"]
 
 
-class TestEmailPageResponse:
+class TestEmailMetadataPageResponse:
     def test_init(self):
         """Test initialization with valid data."""
         now = datetime.now()
-        email_data = EmailData(
+        email_data = EmailMetadata(
+            email_id="123",
             subject="Test Subject",
             sender="test@example.com",
-            body="Test Body",
+            recipients=["recipient@example.com"],
             date=now,
             attachments=[],
         )
 
-        response = EmailPageResponse(
+        response = EmailMetadataPageResponse(
             page=1,
             page_size=10,
             before=now,
             since=None,
             subject="Test",
-            body=None,
-            text=None,
             emails=[email_data],
             total=1,
         )
@@ -69,22 +70,18 @@ class TestEmailPageResponse:
         assert response.before == now
         assert response.since is None
         assert response.subject == "Test"
-        assert response.body is None
-        assert response.text is None
         assert len(response.emails) == 1
         assert response.emails[0] == email_data
         assert response.total == 1
 
     def test_empty_emails(self):
         """Test with empty email list."""
-        response = EmailPageResponse(
+        response = EmailMetadataPageResponse(
             page=1,
             page_size=10,
             before=None,
             since=None,
             subject=None,
-            body=None,
-            text=None,
             emails=[],
             total=0,
         )


### PR DESCRIPTION
Contribute to [Separate retrieval of subject lines and message bodies #35](https://github.com/ai-zerolab/mcp-email-server/issues/35)

**🔧 Key Changes**
Email Model and MCP tool Refactoring:
Renamed `EmailData` → `EmailMetadata` for better semantic clarity
Separated email metadata from content with new models:` EmailMetadataPageResponse`, `EmailBodyResponse`, `EmailContentBatchResponse`

By the way, as I also fall into the time problem, I delete the `created_at` and `updated_at` in config.py while developing, this pull don't include this.
I also changed the tests related to my pull.