### PR TITLE
feat: Add HTML email support with explicit html parameter

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -111,8 +111,12 @@ async def send_email(
         list[str] | None,
         Field(default=None, description="A list of BCC email addresses."),
     ] = None,
+    html: Annotated[
+        bool,
+        Field(default=False, description="Whether to send the email as HTML (True) or plain text (False)."),
+    ] = False,
 ) -> str:
     handler = dispatch_handler(account_name)
-    await handler.send_email(recipients, subject, body, cc, bcc)
+    await handler.send_email(recipients, subject, body, cc, bcc, html)
     recipient_str = ", ".join(recipients)
     return f"Email sent successfully to {recipient_str}"

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -31,7 +31,13 @@ class EmailHandler(abc.ABC):
 
     @abc.abstractmethod
     async def send_email(
-        self, recipients: list[str], subject: str, body: str, cc: list[str] | None = None, bcc: list[str] | None = None
+        self,
+        recipients: list[str],
+        subject: str,
+        body: str,
+        cc: list[str] | None = None,
+        bcc: list[str] | None = None,
+        html: bool = False,
     ) -> None:
         """
         Send email

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -384,10 +384,17 @@ class EmailClient:
                 logger.info(f"Error during logout: {e}")
 
     async def send_email(
-        self, recipients: list[str], subject: str, body: str, cc: list[str] | None = None, bcc: list[str] | None = None
+        self,
+        recipients: list[str],
+        subject: str,
+        body: str,
+        cc: list[str] | None = None,
+        bcc: list[str] | None = None,
+        html: bool = False,
     ):
         # Create message with UTF-8 encoding to support special characters
-        msg = MIMEText(body, "plain", "utf-8")
+        content_type = "html" if html else "plain"
+        msg = MIMEText(body, content_type, "utf-8")
 
         # Handle subject with special characters
         if any(ord(c) > 127 for c in subject):
@@ -500,6 +507,12 @@ class ClassicEmailHandler(EmailHandler):
         )
 
     async def send_email(
-        self, recipients: list[str], subject: str, body: str, cc: list[str] | None = None, bcc: list[str] | None = None
+        self,
+        recipients: list[str],
+        subject: str,
+        body: str,
+        cc: list[str] | None = None,
+        bcc: list[str] | None = None,
+        html: bool = False,
     ) -> None:
-        await self.outgoing_client.send_email(recipients, subject, body, cc, bcc)
+        await self.outgoing_client.send_email(recipients, subject, body, cc, bcc, html)


### PR DESCRIPTION
# 🚀 Add HTML Email Support with Explicit Control

## Problem Solved
Previously, all emails sent through `mcp-email-server` were hardcoded as `text/plain` content type, causing HTML emails to display as raw HTML code instead of being properly rendered in email clients.

## Solution
Added an explicit `html: bool = False` parameter throughout the entire call chain to give LLMs direct control over email content type.

## Changes Made

### 🔧 Core Implementation
- **`app.py`**: Added `html` parameter to the `send_email` MCP tool with proper documentation
- **`emails/__init__.py`**: Updated `EmailHandler` abstract method signature to include `html` parameter
- **`emails/classic.py`**: Updated both `EmailClient` and `ClassicEmailHandler` methods to support HTML emails

### 📋 Technical Details
```python
# Dynamic content type selection
content_type = "html" if html else "plain"
msg = MIMEText(body, content_type, "utf-8")
```

## API Usage

### Plain Text Email (Default)
```python
await send_email("account", ["user@example.com"], "Subject", "Plain text body")
# Result: Content-Type: text/plain; charset="utf-8"
```

### HTML Email (New Feature)
```python
await send_email("account", ["user@example.com"], "Subject", "<h1>HTML content</h1>", html=True)
# Result: Content-Type: text/html; charset="utf-8"
```

## Benefits

✅ **Explicit Control**: LLMs can now explicitly choose HTML vs plain text  
✅ **Backward Compatible**: Defaults to `html=False` (existing behavior preserved)  
✅ **No Auto-Detection**: Eliminates regex pattern matching and potential false positives  
✅ **Clean Implementation**: Simple boolean parameter throughout the call chain  
✅ **Proper Documentation**: Parameter is documented in the MCP tool description

## Testing

The feature has been tested and works correctly:
- HTML emails render properly in email clients when `html=True`
- Plain text emails continue to work exactly as before when `html=False` or omitted
- Email headers show correct `Content-Type: text/html` or `Content-Type: text/plain`

## Impact

This enhancement directly addresses the core issue where HTML content was being sent as plain text, making the MCP email server much more useful for rich email communication scenarios.

---

**Note**: This is a non-breaking change that maintains full backward compatibility while adding powerful new functionality for HTML email support.