### PR TITLE
fix incorrect date-time format in EmailMetadata

### DIFF
--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -26,9 +26,7 @@ class EmailMetadata(BaseModel):
         )
 
     class Config:
-        json_encoders = {
-            datetime: lambda dt: dt.strftime('%Y-%m-%dT%H:%M:%SZ')
-        }
+        json_encoders = {datetime: lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%SZ")}
 
 
 class EmailMetadataPageResponse(BaseModel):


### PR DESCRIPTION
fixing #64 by adding a custom JSON encoder