### PR TITLE
feat: add download_attachment tool for email attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,54 @@ You can also configure the email server using environment variables, which is pa
 
 #### Available Environment Variables
 
-| Variable                          | Description        | Default       | Required |
-| --------------------------------- | ------------------ | ------------- | -------- |
-| `MCP_EMAIL_SERVER_ACCOUNT_NAME`   | Account identifier | `"default"`   | No       |
-| `MCP_EMAIL_SERVER_FULL_NAME`      | Display name       | Email prefix  | No       |
-| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`  | Email address      | -             | Yes      |
-| `MCP_EMAIL_SERVER_USER_NAME`      | Login username     | Same as email | No       |
-| `MCP_EMAIL_SERVER_PASSWORD`       | Email password     | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_HOST`      | IMAP server host   | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_PORT`      | IMAP server port   | `993`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_SSL`       | Enable IMAP SSL    | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`      | SMTP server host   | -             | Yes      |
-| `MCP_EMAIL_SERVER_SMTP_PORT`      | SMTP server port   | `465`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_SSL`       | Enable SMTP SSL    | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_START_SSL` | Enable STARTTLS    | `false`       | No       |
+| Variable                                      | Description                | Default       | Required |
+| --------------------------------------------- | -------------------------- | ------------- | -------- |
+| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier         | `"default"`   | No       |
+| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name               | Email prefix  | No       |
+| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address              | -             | Yes      |
+| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username             | Same as email | No       |
+| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password             | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host           | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port           | `993`         | No       |
+| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL            | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host           | -             | Yes      |
+| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port           | `465`         | No       |
+| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL            | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS            | `false`       | No       |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download | `false`       | No       |
+
+### Enabling Attachment Downloads
+
+By default, downloading email attachments is disabled for security reasons. To enable this feature, you can either:
+
+**Option 1: Environment Variable**
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD": "true"
+      }
+    }
+  }
+}
+```
+
+**Option 2: TOML Configuration**
+
+Add `enable_attachment_download = true` to your TOML configuration file (`~/.config/zerolib/mcp_email_server/config.toml`):
+
+```toml
+enable_attachment_download = true
+
+[[emails]]
+# ... your email configuration
+```
+
+Once enabled, you can use the `download_attachment` tool to save email attachments to a specified path.
 
 For separate IMAP/SMTP credentials, you can also use:
 

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -3,7 +3,11 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from mcp_email_server.emails.models import EmailContentBatchResponse, EmailMetadataPageResponse
+    from mcp_email_server.emails.models import (
+        AttachmentDownloadResponse,
+        EmailContentBatchResponse,
+        EmailMetadataPageResponse,
+    )
 
 
 class EmailHandler(abc.ABC):
@@ -49,4 +53,15 @@ class EmailHandler(abc.ABC):
     async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """
         Delete emails by their IDs. Returns (deleted_ids, failed_ids)
+        """
+
+    @abc.abstractmethod
+    async def download_attachment(
+        self,
+        email_id: str,
+        attachment_name: str,
+        save_path: str,
+    ) -> "AttachmentDownloadResponse":
+        """
+        Download an email attachment and save it to the specified path
         """

--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -57,3 +57,13 @@ class EmailContentBatchResponse(BaseModel):
     requested_count: int
     retrieved_count: int
     failed_ids: list[str]
+
+
+class AttachmentDownloadResponse(BaseModel):
+    """Attachment download response"""
+
+    email_id: str
+    attachment_name: str
+    mime_type: str
+    size: int
+    saved_path: str

--- a/tests/test_env_config_coverage.py
+++ b/tests/test_env_config_coverage.py
@@ -309,3 +309,52 @@ def test_email_settings_masked(monkeypatch):
     assert masked.incoming.password == "********"  # noqa: S105
     assert masked.outgoing.password == "********"  # noqa: S105
     assert masked.email_address == "test@example.com"
+
+
+def test_enable_attachment_download_from_env_true(monkeypatch, tmp_path):
+    """Test enable_attachment_download can be set via environment variable."""
+    config_file = tmp_path / "empty.toml"
+    config_file.write_text("")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CONFIG_PATH", str(config_file))
+
+    # Clear any email env vars
+    for key in list(os.environ.keys()):
+        if key.startswith("MCP_EMAIL_SERVER_") and "CONFIG_PATH" not in key:
+            monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD", "true")
+
+    settings = Settings()
+    assert settings.enable_attachment_download is True
+
+
+def test_enable_attachment_download_from_env_false(monkeypatch, tmp_path):
+    """Test enable_attachment_download=false via environment variable."""
+    config_file = tmp_path / "empty.toml"
+    config_file.write_text("")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CONFIG_PATH", str(config_file))
+
+    for key in list(os.environ.keys()):
+        if key.startswith("MCP_EMAIL_SERVER_") and "CONFIG_PATH" not in key:
+            monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD", "false")
+
+    settings = Settings()
+    assert settings.enable_attachment_download is False
+
+
+def test_enable_attachment_download_env_overrides_toml(monkeypatch, tmp_path):
+    """Test environment variable overrides TOML config for enable_attachment_download."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("enable_attachment_download = false\n")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CONFIG_PATH", str(config_file))
+
+    for key in list(os.environ.keys()):
+        if key.startswith("MCP_EMAIL_SERVER_") and "CONFIG_PATH" not in key:
+            monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD", "1")
+
+    settings = Settings()
+    assert settings.enable_attachment_download is True


### PR DESCRIPTION
Implement email attachment download functionality as requested in #73.

Changes:
- Add AttachmentDownloadResponse model
- Add enable_attachment_download config option (default: false)
- Support MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD env var
- Add download_attachment abstract method to EmailHandler
- Implement download_attachment in ClassicEmailHandler and EmailClient
- Add download_attachment MCP tool with security check
- Update README with configuration documentation
- Add comprehensive tests for the new feature

Closes #73