### PR TITLE
Add IMAP flag-based search filters to list_emails_metadata

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -68,7 +68,19 @@ async def list_emails_metadata(
         Literal["asc", "desc"],
         Field(default=None, description="Order emails by field. `asc` or `desc`."),
     ] = "desc",
-    mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to retrieve emails from.")] = "INBOX",
+    mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to search.")] = "INBOX",
+    seen: Annotated[
+        bool | None,
+        Field(default=None, description="Filter by read status: True=read, False=unread, None=all."),
+    ] = None,
+    flagged: Annotated[
+        bool | None,
+        Field(default=None, description="Filter by flagged/starred status: True=flagged, False=unflagged, None=all."),
+    ] = None,
+    answered: Annotated[
+        bool | None,
+        Field(default=None, description="Filter by replied status: True=replied, False=not replied, None=all."),
+    ] = None,
 ) -> EmailMetadataPageResponse:
     handler = dispatch_handler(account_name)
 
@@ -82,6 +94,9 @@ async def list_emails_metadata(
         to_address=to_address,
         order=order,
         mailbox=mailbox,
+        seen=seen,
+        flagged=flagged,
+        answered=answered,
     )
 
 

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -23,9 +23,26 @@ class EmailHandler(abc.ABC):
         to_address: str | None = None,
         order: str = "desc",
         mailbox: str = "INBOX",
+        seen: bool | None = None,
+        flagged: bool | None = None,
+        answered: bool | None = None,
     ) -> "EmailMetadataPageResponse":
         """
-        Get email metadata only (without body content) for better performance
+        Get email metadata only (without body content) for better performance.
+
+        Args:
+            page: Page number (starting from 1).
+            page_size: Number of emails per page.
+            before: Filter emails before this datetime.
+            since: Filter emails since this datetime.
+            subject: Filter by subject (substring match).
+            from_address: Filter by sender address.
+            to_address: Filter by recipient address.
+            order: Sort order ('asc' or 'desc').
+            mailbox: Mailbox to search (default: 'INBOX').
+            seen: Filter by read status (True=read, False=unread, None=all).
+            flagged: Filter by flagged/starred status (True=flagged, False=unflagged, None=all).
+            answered: Filter by replied status (True=replied, False=not replied, None=all).
         """
 
     @abc.abstractmethod

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -173,6 +173,9 @@ class EmailClient:
         text: str | None = None,
         from_address: str | None = None,
         to_address: str | None = None,
+        seen: bool | None = None,
+        flagged: bool | None = None,
+        answered: bool | None = None,
     ):
         search_criteria = []
         if before:
@@ -190,11 +193,17 @@ class EmailClient:
         if to_address:
             search_criteria.extend(["TO", to_address])
 
-        # If no specific criteria, search for ALL
-        if not search_criteria:
-            search_criteria = ["ALL"]
+        # Flag-based criteria using mapping to reduce complexity
+        flag_criteria = [
+            (seen, {True: "SEEN", False: "UNSEEN"}),
+            (flagged, {True: "FLAGGED", False: "UNFLAGGED"}),
+            (answered, {True: "ANSWERED", False: "UNANSWERED"}),
+        ]
+        for flag_value, criteria_map in flag_criteria:
+            if flag_value in criteria_map:
+                search_criteria.append(criteria_map[flag_value])
 
-        return search_criteria
+        return search_criteria or ["ALL"]
 
     async def get_email_count(
         self,
@@ -204,6 +213,9 @@ class EmailClient:
         from_address: str | None = None,
         to_address: str | None = None,
         mailbox: str = "INBOX",
+        seen: bool | None = None,
+        flagged: bool | None = None,
+        answered: bool | None = None,
     ) -> int:
         imap = self.imap_class(self.email_server.host, self.email_server.port)
         try:
@@ -216,7 +228,14 @@ class EmailClient:
             await _send_imap_id(imap)
             await imap.select(_quote_mailbox(mailbox))
             search_criteria = self._build_search_criteria(
-                before, since, subject, from_address=from_address, to_address=to_address
+                before,
+                since,
+                subject,
+                from_address=from_address,
+                to_address=to_address,
+                seen=seen,
+                flagged=flagged,
+                answered=answered,
             )
             logger.info(f"Count: Search criteria: {search_criteria}")
             # Search for messages and count them - use UID SEARCH for consistency
@@ -240,6 +259,9 @@ class EmailClient:
         to_address: str | None = None,
         order: str = "desc",
         mailbox: str = "INBOX",
+        seen: bool | None = None,
+        flagged: bool | None = None,
+        answered: bool | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         imap = self.imap_class(self.email_server.host, self.email_server.port)
         try:
@@ -253,7 +275,14 @@ class EmailClient:
             await imap.select(_quote_mailbox(mailbox))
 
             search_criteria = self._build_search_criteria(
-                before, since, subject, from_address=from_address, to_address=to_address
+                before,
+                since,
+                subject,
+                from_address=from_address,
+                to_address=to_address,
+                seen=seen,
+                flagged=flagged,
+                answered=answered,
             )
             logger.info(f"Get metadata: Search criteria: {search_criteria}")
 
@@ -818,14 +847,36 @@ class ClassicEmailHandler(EmailHandler):
         to_address: str | None = None,
         order: str = "desc",
         mailbox: str = "INBOX",
+        seen: bool | None = None,
+        flagged: bool | None = None,
+        answered: bool | None = None,
     ) -> EmailMetadataPageResponse:
         emails = []
         async for email_data in self.incoming_client.get_emails_metadata_stream(
-            page, page_size, before, since, subject, from_address, to_address, order, mailbox
+            page,
+            page_size,
+            before,
+            since,
+            subject,
+            from_address,
+            to_address,
+            order,
+            mailbox,
+            seen,
+            flagged,
+            answered,
         ):
             emails.append(EmailMetadata.from_email(email_data))
         total = await self.incoming_client.get_email_count(
-            before, since, subject, from_address=from_address, to_address=to_address, mailbox=mailbox
+            before,
+            since,
+            subject,
+            from_address=from_address,
+            to_address=to_address,
+            mailbox=mailbox,
+            seen=seen,
+            flagged=flagged,
+            answered=answered,
         )
         return EmailMetadataPageResponse(
             page=page,

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -108,10 +108,18 @@ class TestClassicEmailHandler:
 
                 # Verify the client methods were called correctly
                 classic_handler.incoming_client.get_emails_metadata_stream.assert_called_once_with(
-                    1, 10, now, None, "Test", "sender@example.com", None, "desc", "INBOX"
+                    1, 10, now, None, "Test", "sender@example.com", None, "desc", "INBOX", None, None, None
                 )
                 mock_count.assert_called_once_with(
-                    now, None, "Test", from_address="sender@example.com", to_address=None, mailbox="INBOX"
+                    now,
+                    None,
+                    "Test",
+                    from_address="sender@example.com",
+                    to_address=None,
+                    mailbox="INBOX",
+                    seen=None,
+                    flagged=None,
+                    answered=None,
                 )
 
     @pytest.mark.asyncio
@@ -144,9 +152,19 @@ class TestClassicEmailHandler:
 
                 # Verify mailbox parameter was passed correctly
                 classic_handler.incoming_client.get_emails_metadata_stream.assert_called_once_with(
-                    1, 10, None, None, None, None, None, "desc", "Sent"
+                    1, 10, None, None, None, None, None, "desc", "Sent", None, None, None
                 )
-                mock_count.assert_called_once_with(None, None, None, from_address=None, to_address=None, mailbox="Sent")
+                mock_count.assert_called_once_with(
+                    None,
+                    None,
+                    None,
+                    from_address=None,
+                    to_address=None,
+                    mailbox="Sent",
+                    seen=None,
+                    flagged=None,
+                    answered=None,
+                )
 
     @pytest.mark.asyncio
     async def test_send_email(self, classic_handler):

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -139,6 +139,56 @@ class TestEmailClient:
         )
         assert criteria == ["SINCE", "01-JAN-2023", "SUBJECT", "Test", "FROM", "test@example.com"]
 
+        # Test with seen=True (read emails)
+        criteria = EmailClient._build_search_criteria(seen=True)
+        assert criteria == ["SEEN"]
+
+        # Test with seen=False (unread emails)
+        criteria = EmailClient._build_search_criteria(seen=False)
+        assert criteria == ["UNSEEN"]
+
+        # Test with seen=None (all emails - no criteria added)
+        criteria = EmailClient._build_search_criteria(seen=None)
+        assert criteria == ["ALL"]
+
+        # Test with flagged=True (starred emails)
+        criteria = EmailClient._build_search_criteria(flagged=True)
+        assert criteria == ["FLAGGED"]
+
+        # Test with flagged=False (non-starred emails)
+        criteria = EmailClient._build_search_criteria(flagged=False)
+        assert criteria == ["UNFLAGGED"]
+
+        # Test with answered=True (replied emails)
+        criteria = EmailClient._build_search_criteria(answered=True)
+        assert criteria == ["ANSWERED"]
+
+        # Test with answered=False (not replied emails)
+        criteria = EmailClient._build_search_criteria(answered=False)
+        assert criteria == ["UNANSWERED"]
+
+        # Test compound criteria: unread emails from a specific sender
+        criteria = EmailClient._build_search_criteria(seen=False, from_address="sender@example.com")
+        assert "UNSEEN" in criteria
+        assert "FROM" in criteria
+        assert "sender@example.com" in criteria
+
+        # Test compound criteria: flagged and answered
+        criteria = EmailClient._build_search_criteria(flagged=True, answered=True)
+        assert "FLAGGED" in criteria
+        assert "ANSWERED" in criteria
+
+        # Test compound criteria: unread, flagged, from specific sender, with subject
+        criteria = EmailClient._build_search_criteria(
+            seen=False, flagged=True, from_address="test@example.com", subject="Important"
+        )
+        assert "UNSEEN" in criteria
+        assert "FLAGGED" in criteria
+        assert "FROM" in criteria
+        assert "test@example.com" in criteria
+        assert "SUBJECT" in criteria
+        assert "Important" in criteria
+
     @pytest.mark.asyncio
     async def test_get_emails_stream(self, email_client):
         """Test getting emails stream."""

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -169,6 +169,9 @@ class TestMcpTools:
                 to_address=None,
                 order="desc",
                 mailbox="INBOX",
+                seen=None,
+                flagged=None,
+                answered=None,
             )
 
     @pytest.mark.asyncio
@@ -214,6 +217,9 @@ class TestMcpTools:
                 to_address=None,
                 order="desc",
                 mailbox="Sent",
+                seen=None,
+                flagged=None,
+                answered=None,
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `seen`, `flagged`, `answered` tri-state filter parameters to `list_emails_metadata`
- Enable compound IMAP searches (e.g., unread emails from a specific sender)

### New Parameters
| Parameter | Values | Description |
|-----------|--------|-------------|
| `seen` | `true`/`false`/`null` | Filter by read status (SEEN/UNSEEN) |
| `flagged` | `true`/`false`/`null` | Filter by starred status (FLAGGED/UNFLAGGED) |
| `answered` | `true`/`false`/`null` | Filter by replied status (ANSWERED/UNANSWERED) |

### Example Usage
```python
# Get unread emails from a specific sender
list_emails_metadata(account_name="work", seen=False, from_address="boss@example.com")

# Get flagged/starred emails
list_emails_metadata(account_name="work", flagged=True)
```

## Test plan
- [x] Unit tests added for `_build_search_criteria` method
- [x] Integration tests updated for handler and MCP tools
- [x] All 110 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)