### PR TITLE
feat: Add mark_emails tool for marking emails as read/unread

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -197,9 +197,7 @@ async def delete_emails(
     return result
 
 
-@mcp.tool(
-    description="Mark one or more emails as read or unread. Use list_emails_metadata first to get the email_id."
-)
+@mcp.tool(description="Mark one or more emails as read or unread. Use list_emails_metadata first to get the email_id.")
 async def mark_emails(
     account_name: Annotated[str, Field(description="The name of the email account.")],
     email_ids: Annotated[
@@ -210,7 +208,13 @@ async def mark_emails(
         Literal["read", "unread"],
         Field(description="Mark emails as 'read' or 'unread'."),
     ],
-    mailbox: Annotated[str, Field(default="INBOX", description="IMAP folder path. Standard: INBOX, Sent, Drafts, Trash. Provider-specific: Gmail uses '[Gmail]/...' prefix; ProtonMail Bridge uses 'Folders/<name>' and 'Labels/<name>'.")] = "INBOX",
+    mailbox: Annotated[
+        str,
+        Field(
+            default="INBOX",
+            description="IMAP folder path. Standard: INBOX, Sent, Drafts, Trash. Provider-specific: Gmail uses '[Gmail]/...' prefix; ProtonMail Bridge uses 'Folders/<name>' and 'Labels/<name>'.",
+        ),
+    ] = "INBOX",
 ) -> EmailMarkResponse:
     handler = dispatch_handler(account_name)
     return await handler.mark_emails(email_ids, mark_as, mailbox)

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -113,9 +113,13 @@ async def get_emails_content(
         ),
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to retrieve emails from.")] = "INBOX",
+    mark_as_read: Annotated[
+        bool,
+        Field(default=False, description="Mark fetched emails as read. Default: False (emails remain unread)."),
+    ] = False,
 ) -> EmailContentBatchResponse:
     handler = dispatch_handler(account_name)
-    return await handler.get_emails_content(email_ids, mailbox)
+    return await handler.get_emails_content(email_ids, mailbox, mark_as_read=mark_as_read)
 
 
 @mcp.tool(

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -14,6 +14,7 @@ from mcp_email_server.emails.dispatcher import dispatch_handler
 from mcp_email_server.emails.models import (
     AttachmentDownloadResponse,
     EmailContentBatchResponse,
+    EmailMarkResponse,
     EmailMetadataPageResponse,
 )
 
@@ -194,6 +195,25 @@ async def delete_emails(
     if failed_ids:
         result += f", failed to delete {len(failed_ids)} email(s): {', '.join(failed_ids)}"
     return result
+
+
+@mcp.tool(
+    description="Mark one or more emails as read or unread. Use list_emails_metadata first to get the email_id."
+)
+async def mark_emails(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    email_ids: Annotated[
+        list[str],
+        Field(description="List of email_id to mark (obtained from list_emails_metadata)."),
+    ],
+    mark_as: Annotated[
+        Literal["read", "unread"],
+        Field(description="Mark emails as 'read' or 'unread'."),
+    ],
+    mailbox: Annotated[str, Field(default="INBOX", description="IMAP folder path. Standard: INBOX, Sent, Drafts, Trash. Provider-specific: Gmail uses '[Gmail]/...' prefix; ProtonMail Bridge uses 'Folders/<name>' and 'Labels/<name>'.")] = "INBOX",
+) -> EmailMarkResponse:
+    handler = dispatch_handler(account_name)
+    return await handler.mark_emails(email_ids, mark_as, mailbox)
 
 
 @mcp.tool(

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -47,9 +47,16 @@ class EmailHandler(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def get_emails_content(self, email_ids: list[str], mailbox: str = "INBOX") -> "EmailContentBatchResponse":
+    async def get_emails_content(
+        self, email_ids: list[str], mailbox: str = "INBOX", mark_as_read: bool = False
+    ) -> "EmailContentBatchResponse":
         """
-        Get full content (including body) of multiple emails by their email IDs (IMAP UIDs)
+        Get full content (including body) of multiple emails by their email IDs (IMAP UIDs).
+
+        Args:
+            email_ids: List of email UIDs to retrieve.
+            mailbox: Mailbox to search in.
+            mark_as_read: If True, mark successfully fetched emails as read.
         """
 
     @abc.abstractmethod

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from mcp_email_server.emails.models import (
         AttachmentDownloadResponse,
         EmailContentBatchResponse,
+        EmailMarkResponse,
         EmailMetadataPageResponse,
     )
 
@@ -83,6 +84,25 @@ class EmailHandler(abc.ABC):
     async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """
         Delete emails by their IDs. Returns (deleted_ids, failed_ids)
+        """
+
+    @abc.abstractmethod
+    async def mark_emails(
+        self,
+        email_ids: list[str],
+        mark_as: str,
+        mailbox: str = "INBOX",
+    ) -> "EmailMarkResponse":
+        """
+        Mark emails as read or unread.
+
+        Args:
+            email_ids: List of email UIDs to mark.
+            mark_as: Either "read" or "unread".
+            mailbox: The mailbox containing the emails (default: "INBOX").
+
+        Returns:
+            EmailMarkResponse with operation results.
         """
 
     @abc.abstractmethod

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -572,7 +572,7 @@ class EmailClient:
 
     async def _fetch_email_with_formats(self, imap, email_id: str) -> list | None:
         """Try different fetch formats to get email data."""
-        fetch_formats = ["RFC822", "BODY[]", "BODY.PEEK[]", "(BODY.PEEK[])"]
+        fetch_formats = ["BODY.PEEK[]", "(BODY.PEEK[])", "RFC822", "BODY[]"]
 
         for fetch_format in fetch_formats:
             try:
@@ -1084,7 +1084,9 @@ class ClassicEmailHandler(EmailHandler):
             total=total,
         )
 
-    async def get_emails_content(self, email_ids: list[str], mailbox: str = "INBOX") -> EmailContentBatchResponse:
+    async def get_emails_content(
+        self, email_ids: list[str], mailbox: str = "INBOX", mark_as_read: bool = False
+    ) -> EmailContentBatchResponse:
         """Batch retrieve email body content"""
         emails = []
         failed_ids = []
@@ -1110,6 +1112,10 @@ class ClassicEmailHandler(EmailHandler):
             except Exception as e:
                 logger.error(f"Failed to retrieve email {email_id}: {e}")
                 failed_ids.append(email_id)
+
+        if mark_as_read and emails:
+            successful_ids = [e.email_id for e in emails]
+            await self.incoming_client.mark_emails(successful_ids, "read", mailbox)
 
         return EmailContentBatchResponse(
             emails=emails,

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -24,6 +24,7 @@ from mcp_email_server.emails.models import (
     AttachmentDownloadResponse,
     EmailBodyResponse,
     EmailContentBatchResponse,
+    EmailMarkResponse,
     EmailMetadata,
     EmailMetadataPageResponse,
 )
@@ -982,6 +983,43 @@ class EmailClient:
 
         return deleted_ids, failed_ids
 
+    async def mark_emails(
+        self, email_ids: list[str], mark_as: str, mailbox: str = "INBOX"
+    ) -> tuple[list[str], list[str]]:
+        """Mark emails as read or unread. Returns (marked_ids, failed_ids)."""
+        if mark_as == "read":
+            flag_op = "+FLAGS"
+        elif mark_as == "unread":
+            flag_op = "-FLAGS"
+        else:
+            raise ValueError(f"Invalid mark_as value: {mark_as}. Must be 'read' or 'unread'.")
+
+        imap = self._imap_connect()
+        marked_ids: list[str] = []
+        failed_ids: list[str] = []
+
+        try:
+            await imap._client_task
+            await imap.wait_hello_from_server()
+            await imap.login(self.email_server.user_name, self.email_server.password.get_secret_value())
+            await _send_imap_id(imap)
+            await imap.select(_quote_mailbox(mailbox))
+
+            for email_id in email_ids:
+                try:
+                    await imap.uid("store", email_id, flag_op, r"(\Seen)")
+                    marked_ids.append(email_id)
+                except Exception as e:
+                    logger.error(f"Failed to mark email {email_id} as {mark_as}: {e}")
+                    failed_ids.append(email_id)
+        finally:
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
+        return marked_ids, failed_ids
+
 
 class ClassicEmailHandler(EmailHandler):
     def __init__(self, email_settings: EmailSettings):
@@ -1110,6 +1148,22 @@ class ClassicEmailHandler(EmailHandler):
     async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """Delete emails by their UIDs. Returns (deleted_ids, failed_ids)."""
         return await self.incoming_client.delete_emails(email_ids, mailbox)
+
+    async def mark_emails(
+        self,
+        email_ids: list[str],
+        mark_as: str,
+        mailbox: str = "INBOX",
+    ) -> EmailMarkResponse:
+        """Mark emails as read or unread."""
+        marked_ids, failed_ids = await self.incoming_client.mark_emails(email_ids, mark_as, mailbox)
+        return EmailMarkResponse(
+            success=len(failed_ids) == 0,
+            marked_ids=marked_ids,
+            failed_ids=failed_ids,
+            mailbox=mailbox,
+            marked_as=mark_as,
+        )
 
     async def download_attachment(
         self,

--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -55,6 +55,16 @@ class EmailContentBatchResponse(BaseModel):
     failed_ids: list[str]
 
 
+class EmailMarkResponse(BaseModel):
+    """Response for mark_emails (read/unread) operations"""
+
+    success: bool
+    marked_ids: list[str]
+    failed_ids: list[str]
+    mailbox: str
+    marked_as: str  # "read" or "unread"
+
+
 class AttachmentDownloadResponse(BaseModel):
     """Attachment download response"""
 

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -365,6 +365,67 @@ class TestClassicEmailHandler:
             # Verify the client method was called correctly
             mock_get_body.assert_called_once_with("123", "INBOX")
 
+    @pytest.mark.asyncio
+    async def test_get_emails_content_mark_as_read_true(self, classic_handler):
+        """Test that mark_as_read=True calls mark_emails on successful fetches."""
+        now = datetime.now(timezone.utc)
+        email_data = {
+            "email_id": "123",
+            "message_id": "<test@example.com>",
+            "subject": "Test",
+            "from": "sender@example.com",
+            "to": ["recipient@example.com"],
+            "date": now,
+            "body": "Test body",
+            "attachments": [],
+        }
+
+        mock_get_body = AsyncMock(return_value=email_data)
+        mock_mark = AsyncMock(return_value=(["123"], []))
+
+        with (
+            patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get_body),
+            patch.object(classic_handler.incoming_client, "mark_emails", mock_mark),
+        ):
+            result = await classic_handler.get_emails_content(
+                email_ids=["123"],
+                mailbox="INBOX",
+                mark_as_read=True,
+            )
+
+            assert result.retrieved_count == 1
+            mock_mark.assert_called_once_with(["123"], "read", "INBOX")
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_mark_as_read_false(self, classic_handler):
+        """Test that mark_as_read=False (default) does not call mark_emails."""
+        now = datetime.now(timezone.utc)
+        email_data = {
+            "email_id": "123",
+            "message_id": "<test@example.com>",
+            "subject": "Test",
+            "from": "sender@example.com",
+            "to": ["recipient@example.com"],
+            "date": now,
+            "body": "Test body",
+            "attachments": [],
+        }
+
+        mock_get_body = AsyncMock(return_value=email_data)
+        mock_mark = AsyncMock()
+
+        with (
+            patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get_body),
+            patch.object(classic_handler.incoming_client, "mark_emails", mock_mark),
+        ):
+            result = await classic_handler.get_emails_content(
+                email_ids=["123"],
+                mailbox="INBOX",
+            )
+
+            assert result.retrieved_count == 1
+            mock_mark.assert_not_called()
+
 
 class TestEmailClientBatchMethods:
     """Test batch fetch methods for performance optimization."""

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -721,3 +721,139 @@ class TestBatchFetchHeaders:
         assert len(result) == 2
         assert result["100"]["subject"] == "First"
         assert result["200"]["subject"] == "Second"
+
+
+class TestMarkEmails:
+    """Tests for mark_emails method."""
+
+    @pytest.mark.asyncio
+    async def test_mark_emails_as_read_success(self, email_client):
+        """Test marking emails as read successfully."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.uid = AsyncMock(return_value=(None, None))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            marked_ids, failed_ids = await email_client.mark_emails(
+                email_ids=["123", "456"],
+                mark_as="read",
+                mailbox="INBOX",
+            )
+
+            assert marked_ids == ["123", "456"]
+            assert failed_ids == []
+            # Verify +FLAGS was used for marking as read
+            calls = mock_imap.uid.call_args_list
+            assert len(calls) == 2
+            assert calls[0][0] == ("store", "123", "+FLAGS", r"(\Seen)")
+            assert calls[1][0] == ("store", "456", "+FLAGS", r"(\Seen)")
+
+    @pytest.mark.asyncio
+    async def test_mark_emails_as_unread_success(self, email_client):
+        """Test marking emails as unread successfully."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.uid = AsyncMock(return_value=(None, None))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            marked_ids, failed_ids = await email_client.mark_emails(
+                email_ids=["123", "456"],
+                mark_as="unread",
+                mailbox="INBOX",
+            )
+
+            assert marked_ids == ["123", "456"]
+            assert failed_ids == []
+            # Verify -FLAGS was used for marking as unread
+            calls = mock_imap.uid.call_args_list
+            assert len(calls) == 2
+            assert calls[0][0] == ("store", "123", "-FLAGS", r"(\Seen)")
+            assert calls[1][0] == ("store", "456", "-FLAGS", r"(\Seen)")
+
+    @pytest.mark.asyncio
+    async def test_mark_emails_partial_failure(self, email_client):
+        """Test marking emails with some failures."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        # First call succeeds, second raises exception
+        mock_imap.uid = AsyncMock(side_effect=[None, Exception("Email not found")])
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            marked_ids, failed_ids = await email_client.mark_emails(
+                email_ids=["123", "456"],
+                mark_as="read",
+                mailbox="INBOX",
+            )
+
+            assert marked_ids == ["123"]
+            assert failed_ids == ["456"]
+
+    @pytest.mark.asyncio
+    async def test_mark_emails_invalid_mark_as_value(self, email_client):
+        """Test that invalid mark_as value raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            await email_client.mark_emails(
+                email_ids=["123"],
+                mark_as="invalid",
+                mailbox="INBOX",
+            )
+        assert "Invalid mark_as value" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_mark_emails_custom_mailbox(self, email_client):
+        """Test marking emails in a custom mailbox."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.uid = AsyncMock(return_value=(None, None))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            await email_client.mark_emails(
+                email_ids=["123"],
+                mark_as="read",
+                mailbox="[Gmail]/All Mail",
+            )
+
+            # Verify custom mailbox was selected (quoted)
+            mock_imap.select.assert_called_once_with('"[Gmail]/All Mail"')
+
+    @pytest.mark.asyncio
+    async def test_mark_emails_logout_error(self, email_client):
+        """Test mark_emails handles logout errors gracefully (covers logout exception handler)."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.uid = AsyncMock(return_value=(None, None))
+        mock_imap.logout = AsyncMock(side_effect=OSError("Connection closed"))
+
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            # Should complete successfully despite logout error
+            marked_ids, failed_ids = await email_client.mark_emails(
+                email_ids=["123"],
+                mark_as="read",
+                mailbox="INBOX",
+            )
+            assert marked_ids == ["123"]
+            assert failed_ids == []

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -321,7 +321,9 @@ class TestMcpTools:
             assert result.emails[1].email_id == "12346"
 
             # Verify dispatch_handler and get_emails_content were called correctly
-            mock_handler.get_emails_content.assert_called_once_with(["12345", "12346", "12347"], "INBOX", mark_as_read=False)
+            mock_handler.get_emails_content.assert_called_once_with(
+                ["12345", "12346", "12347"], "INBOX", mark_as_read=False
+            )
 
     @pytest.mark.asyncio
     async def test_get_emails_content_with_mailbox(self):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -265,7 +265,7 @@ class TestMcpTools:
             assert result.emails[0].subject == "Test Subject"
 
             # Verify dispatch_handler and get_emails_content were called correctly
-            mock_handler.get_emails_content.assert_called_once_with(["12345"], "INBOX")
+            mock_handler.get_emails_content.assert_called_once_with(["12345"], "INBOX", mark_as_read=False)
 
     @pytest.mark.asyncio
     async def test_get_emails_content_batch(self):
@@ -321,7 +321,7 @@ class TestMcpTools:
             assert result.emails[1].email_id == "12346"
 
             # Verify dispatch_handler and get_emails_content were called correctly
-            mock_handler.get_emails_content.assert_called_once_with(["12345", "12346", "12347"], "INBOX")
+            mock_handler.get_emails_content.assert_called_once_with(["12345", "12346", "12347"], "INBOX", mark_as_read=False)
 
     @pytest.mark.asyncio
     async def test_get_emails_content_with_mailbox(self):
@@ -355,7 +355,39 @@ class TestMcpTools:
             )
 
             assert result == batch_response
-            mock_handler.get_emails_content.assert_called_once_with(["12345"], "Sent")
+            mock_handler.get_emails_content.assert_called_once_with(["12345"], "Sent", mark_as_read=False)
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_mark_as_read(self):
+        """Test that mark_as_read parameter is passed through to handler."""
+        mock_handler = AsyncMock()
+        mock_handler.get_emails_content = AsyncMock(
+            return_value=EmailContentBatchResponse(
+                emails=[
+                    EmailBodyResponse(
+                        email_id="123",
+                        subject="Test",
+                        sender="sender@example.com",
+                        recipients=["recipient@example.com"],
+                        date=datetime.now(timezone.utc),
+                        body="Test body",
+                        attachments=[],
+                    )
+                ],
+                requested_count=1,
+                retrieved_count=1,
+                failed_ids=[],
+            )
+        )
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            await get_emails_content(
+                account_name="test",
+                email_ids=["123"],
+                mark_as_read=True,
+            )
+
+            mock_handler.get_emails_content.assert_called_once_with(["123"], "INBOX", mark_as_read=True)
 
     @pytest.mark.asyncio
     async def test_send_email(self):


### PR DESCRIPTION
## Summary
- Adds `mark_emails` MCP tool to mark emails as read or unread using IMAP `\Seen` flag
- New `EmailMarkResponse` model for operation results
- Supports batch operations with success/failure tracking per email

## Changes
- `mcp_email_server/emails/models.py` - Added `EmailMarkResponse` model
- `mcp_email_server/emails/__init__.py` - Added abstract `mark_emails` method to `EmailHandler`
- `mcp_email_server/emails/classic.py` - Implemented in `EmailClient` and `ClassicEmailHandler`
- `mcp_email_server/app.py` - Exposed MCP tool with `mark_as` parameter (`"read"` or `"unread"`)

## Test plan
- [ ] Test marking single email as read
- [ ] Test marking single email as unread
- [ ] Test batch marking multiple emails
- [ ] Test with different mailboxes (INBOX, custom folders)
- [ ] Verify failed_ids tracking when email doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)