### PR TITLE
feat: add mailbox management tools (list, create, move)

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -219,3 +219,48 @@ async def download_attachment(
 
     handler = dispatch_handler(account_name)
     return await handler.download_attachment(email_id, attachment_name, save_path, mailbox)
+
+
+@mcp.tool(description="List all available mailboxes/folders for an email account.")
+async def list_mailboxes(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+) -> list[str]:
+    handler = dispatch_handler(account_name)
+    return await handler.list_mailboxes()
+
+
+@mcp.tool(
+    description="Move one or more emails to another mailbox/folder. Use list_emails_metadata first to get email_ids and list_mailboxes to see available folders."
+)
+async def move_emails(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    email_ids: Annotated[
+        list[str],
+        Field(description="List of email_id to move (obtained from list_emails_metadata)."),
+    ],
+    target_mailbox: Annotated[str, Field(description="The target mailbox/folder to move emails to.")],
+    source_mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox to move emails from.")] = "INBOX",
+) -> str:
+    handler = dispatch_handler(account_name)
+    moved_ids, failed_ids = await handler.move_emails(email_ids, target_mailbox, source_mailbox)
+
+    result = f"Successfully moved {len(moved_ids)} email(s) to '{target_mailbox}'"
+    if failed_ids:
+        result += f", failed to move {len(failed_ids)} email(s): {', '.join(failed_ids)}"
+    return result
+
+
+@mcp.tool(
+    description="Create a new mailbox/folder. Use this to organize emails with custom folders."
+)
+async def create_mailbox(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    mailbox_name: Annotated[str, Field(description="The name of the mailbox/folder to create.")],
+) -> str:
+    handler = dispatch_handler(account_name)
+    success = await handler.create_mailbox(mailbox_name)
+
+    if success:
+        return f"Successfully created mailbox '{mailbox_name}'"
+    else:
+        return f"Failed to create mailbox '{mailbox_name}'"

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -239,7 +239,9 @@ async def move_emails(
         Field(description="List of email_id to move (obtained from list_emails_metadata)."),
     ],
     target_mailbox: Annotated[str, Field(description="The target mailbox/folder to move emails to.")],
-    source_mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox to move emails from.")] = "INBOX",
+    source_mailbox: Annotated[
+        str, Field(default="INBOX", description="The source mailbox to move emails from.")
+    ] = "INBOX",
 ) -> str:
     handler = dispatch_handler(account_name)
     moved_ids, failed_ids = await handler.move_emails(email_ids, target_mailbox, source_mailbox)
@@ -250,9 +252,7 @@ async def move_emails(
     return result
 
 
-@mcp.tool(
-    description="Create a new mailbox/folder. Use this to organize emails with custom folders."
-)
+@mcp.tool(description="Create a new mailbox/folder. Use this to organize emails with custom folders.")
 async def create_mailbox(
     account_name: Annotated[str, Field(description="The name of the email account.")],
     mailbox_name: Annotated[str, Field(description="The name of the mailbox/folder to create.")],

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -92,3 +92,40 @@ class EmailHandler(abc.ABC):
         Returns:
             AttachmentDownloadResponse with download result information.
         """
+
+    @abc.abstractmethod
+    async def list_mailboxes(self) -> list[str]:
+        """
+        List all available mailboxes/folders.
+
+        Returns:
+            List of mailbox names.
+        """
+
+    @abc.abstractmethod
+    async def move_emails(
+        self, email_ids: list[str], target_mailbox: str, source_mailbox: str = "INBOX"
+    ) -> tuple[list[str], list[str]]:
+        """
+        Move emails to another mailbox.
+
+        Args:
+            email_ids: List of email UIDs to move.
+            target_mailbox: Target mailbox name.
+            source_mailbox: Source mailbox name (default: "INBOX").
+
+        Returns:
+            Tuple of (moved_ids, failed_ids).
+        """
+
+    @abc.abstractmethod
+    async def create_mailbox(self, mailbox_name: str) -> bool:
+        """
+        Create a new mailbox/folder.
+
+        Args:
+            mailbox_name: The name of the mailbox to create.
+
+        Returns:
+            True if successfully created, False otherwise.
+        """


### PR DESCRIPTION
## Summary

Adds three new MCP tools for mailbox/folder management:

- `list_mailboxes` - List all available mailboxes/folders for an email account
- `create_mailbox` - Create a new mailbox/folder
- `move_emails` - Move one or more emails to another mailbox/folder

## Changes

- Added abstract methods to `EmailHandler` interface
- Implemented methods in `EmailClient` and `ClassicEmailHandler`
- Added MCP tool definitions in `app.py`
- Uses COPY + DELETE + EXPUNGE pattern for move operations (IMAP compatibility)
- Proper mailbox name quoting via existing `_quote_mailbox()` for RFC 3501 compliance

## Use Cases

- Organize emails into custom folders
- Archive old emails
- Implement email workflow automation

## Test Plan

- [x] Tested `list_mailboxes` with Yandex Mail
- [x] Tested `create_mailbox` creates folder successfully
- [x] Tested `move_emails` moves messages and removes from source
- [x] Tested with mailbox names containing special characters