### PR TITLE
refactor: simplify code and reduce duplication

### DIFF
--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -17,9 +17,16 @@ from pydantic_settings import (
 
 from mcp_email_server.log import logger
 
-DEFAILT_CONFIG_PATH = "~/.config/zerolib/mcp_email_server/config.toml"
+DEFAULT_CONFIG_PATH = "~/.config/zerolib/mcp_email_server/config.toml"
 
-CONFIG_PATH = Path(os.getenv("MCP_EMAIL_SERVER_CONFIG_PATH", DEFAILT_CONFIG_PATH)).expanduser().resolve()
+
+def _parse_bool_env(value: str | None, default: bool = False) -> bool:
+    """Parse boolean value from environment variable."""
+    if value is None:
+        return default
+    return value.lower() in ("true", "1", "yes", "on")
+
+CONFIG_PATH = Path(os.getenv("MCP_EMAIL_SERVER_CONFIG_PATH", DEFAULT_CONFIG_PATH)).expanduser().resolve()
 
 
 class EmailServer(BaseModel):
@@ -155,12 +162,6 @@ class EmailSettings(AccountAttributes):
         if not email_address or not password:
             return None
 
-        # Parse boolean values
-        def parse_bool(value: str | None, default: bool = True) -> bool:
-            if value is None:
-                return default
-            return value.lower() in ("true", "1", "yes", "on")
-
         # Get all environment variables with defaults
         account_name = os.getenv("MCP_EMAIL_SERVER_ACCOUNT_NAME", "default")
         full_name = os.getenv("MCP_EMAIL_SERVER_FULL_NAME", email_address.split("@")[0])
@@ -182,17 +183,17 @@ class EmailSettings(AccountAttributes):
                 password=password,
                 imap_host=imap_host,
                 imap_port=int(os.getenv("MCP_EMAIL_SERVER_IMAP_PORT", "993")),
-                imap_ssl=parse_bool(os.getenv("MCP_EMAIL_SERVER_IMAP_SSL"), True),
+                imap_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_SSL"), True),
                 smtp_host=smtp_host,
                 smtp_port=int(os.getenv("MCP_EMAIL_SERVER_SMTP_PORT", "465")),
-                smtp_ssl=parse_bool(os.getenv("MCP_EMAIL_SERVER_SMTP_SSL"), True),
-                smtp_start_ssl=parse_bool(os.getenv("MCP_EMAIL_SERVER_SMTP_START_SSL"), False),
-                smtp_verify_ssl=parse_bool(os.getenv("MCP_EMAIL_SERVER_SMTP_VERIFY_SSL"), True),
+                smtp_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_SSL"), True),
+                smtp_start_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_START_SSL"), False),
+                smtp_verify_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_VERIFY_SSL"), True),
                 smtp_user_name=os.getenv("MCP_EMAIL_SERVER_SMTP_USER_NAME", user_name),
                 smtp_password=os.getenv("MCP_EMAIL_SERVER_SMTP_PASSWORD", password),
                 imap_user_name=os.getenv("MCP_EMAIL_SERVER_IMAP_USER_NAME", user_name),
                 imap_password=os.getenv("MCP_EMAIL_SERVER_IMAP_PASSWORD", password),
-                save_to_sent=parse_bool(os.getenv("MCP_EMAIL_SERVER_SAVE_TO_SENT"), True),
+                save_to_sent=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SAVE_TO_SENT"), True),
                 sent_folder_name=os.getenv("MCP_EMAIL_SERVER_SENT_FOLDER_NAME"),
             )
         except (ValueError, TypeError) as e:
@@ -214,13 +215,6 @@ class ProviderSettings(AccountAttributes):
 
     def masked(self) -> AccountAttributes:
         return self.model_copy(update={"api_key": "********"})
-
-
-def _parse_bool_env(value: str | None, default: bool = False) -> bool:
-    """Parse boolean value from environment variable."""
-    if value is None:
-        return default
-    return value.lower() in ("true", "1", "yes", "on")
 
 
 class Settings(BaseSettings):
@@ -343,7 +337,6 @@ def store_settings(settings: Settings | None = None) -> None:
     if not settings:
         settings = get_settings()
     settings.store()
-    return
 
 
 def delete_settings() -> None:

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -26,6 +26,7 @@ def _parse_bool_env(value: str | None, default: bool = False) -> bool:
         return default
     return value.lower() in ("true", "1", "yes", "on")
 
+
 CONFIG_PATH = Path(os.getenv("MCP_EMAIL_SERVER_CONFIG_PATH", DEFAULT_CONFIG_PATH)).expanduser().resolve()
 
 

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -61,9 +61,22 @@ class EmailHandler(abc.ABC):
         bcc: list[str] | None = None,
         html: bool = False,
         attachments: list[str] | None = None,
+        in_reply_to: str | None = None,
+        references: str | None = None,
     ) -> None:
         """
         Send email
+
+        Args:
+            recipients: List of recipient email addresses.
+            subject: Email subject.
+            body: Email body content.
+            cc: List of CC email addresses.
+            bcc: List of BCC email addresses.
+            html: Whether to send as HTML (True) or plain text (False).
+            attachments: List of file paths to attach.
+            in_reply_to: Message-ID of the email being replied to (for threading).
+            references: Space-separated Message-IDs for the thread chain.
         """
 
     @abc.abstractmethod

--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -40,17 +40,10 @@ class EmailMetadataPageResponse(BaseModel):
     total: int
 
 
-class EmailBodyResponse(BaseModel):
-    """Single email body response"""
+class EmailBodyResponse(EmailMetadata):
+    """Single email body response - extends EmailMetadata with body content"""
 
-    email_id: str  # IMAP UID of this email
-    message_id: str | None = None  # RFC 5322 Message-ID header for reply threading
-    subject: str
-    sender: str
-    recipients: list[str]
-    date: datetime
     body: str
-    attachments: list[str]
 
 
 class EmailContentBatchResponse(BaseModel):


### PR DESCRIPTION
## Summary

- Fix typo: `DEFAILT_CONFIG_PATH` -> `DEFAULT_CONFIG_PATH`
- Consolidate duplicate `_parse_bool_env` functions into one module-level function
- Remove unnecessary `return` statement in `store_settings`
- Have `EmailBodyResponse` extend `EmailMetadata` to avoid field duplication
- Add `in_reply_to` and `references` params to abstract `send_email` interface to match implementation
- Extract `_parse_recipients` and `_parse_date` helper methods in `EmailClient` to reduce code duplication
- Add `MAX_BODY_LENGTH` constant instead of magic number `20000`
- Add missing return type annotation to `_build_search_criteria`

## Test plan

- [x] All existing tests pass (130 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)