### PR TITLE
Fix: _batch_fetch_headers UID parsing for aioimaplib response format

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -343,8 +343,15 @@ class EmailClient:
         for i, item in enumerate(data):
             if not isinstance(item, bytes) or b"BODY[HEADER]" not in item:
                 continue
-            uid_match = re.search(rb"UID (\d+)", item)
-            if uid_match and i + 1 < len(data) and isinstance(data[i + 1], bytearray):
+            # aioimaplib returns FETCH response in 3 parts:
+            # i:   b'N FETCH (BODY[HEADER] {size}'  - contains BODY[HEADER]
+            # i+1: bytearray(...)                   - raw header content
+            # i+2: b' UID N)'                       - contains UID
+            if i + 2 >= len(data) or not isinstance(data[i + 1], bytearray):
+                continue
+            uid_item = data[i + 2] if isinstance(data[i + 2], bytes) else None
+            uid_match = re.search(rb"UID (\d+)", uid_item) if uid_item else None
+            if uid_match:
                 uid = uid_match.group(1).decode()
                 raw_headers = bytes(data[i + 1])
                 metadata = self._parse_headers(uid, raw_headers)

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -457,13 +457,16 @@ Subject: No Date Email
     async def test_batch_fetch_headers_parses_response(self, email_client):
         """Test _batch_fetch_headers correctly parses IMAP BODY[HEADER] response."""
         mock_imap = AsyncMock()
-        # Simulate IMAP response format for BODY[HEADER]
+        # aioimaplib returns FETCH response in 3 parts:
+        # - BODY[HEADER] line (no UID)
+        # - header content as bytearray
+        # - UID line
         mock_imap.uid.return_value = (
             "OK",
             [
-                b"1 FETCH (UID 100 BODY[HEADER] {100}",
+                b"1 FETCH (BODY[HEADER] {100}",
                 bytearray(b"From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\n\r\n"),
-                b")",
+                b" UID 100)",
             ],
         )
 

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -590,13 +590,17 @@ class TestBatchFetchHeaders:
     async def test_batch_fetch_headers_parses_imap_response(self, email_client):
         """Test that _batch_fetch_headers correctly parses IMAP header responses."""
         mock_imap = AsyncMock()
+        # aioimaplib returns FETCH response in 3 parts:
+        # - BODY[HEADER] line (no UID)
+        # - header content as bytearray
+        # - UID line
         mock_imap.uid = AsyncMock(
             return_value=(
                 None,
                 [
-                    b"1 FETCH (UID 100 BODY[HEADER] {50}",
+                    b"1 FETCH (BODY[HEADER] {50}",
                     bytearray(b"From: a@test.com\r\nSubject: Test\r\n\r\n"),
-                    b")",
+                    b" UID 100)",
                     b"FETCH completed",
                 ],
             )
@@ -620,16 +624,17 @@ class TestBatchFetchHeaders:
     async def test_batch_fetch_headers_preserves_uid_mapping(self, email_client):
         """Test that _batch_fetch_headers returns dict keyed by UID."""
         mock_imap = AsyncMock()
+        # aioimaplib returns each email as 3 items: BODY[HEADER] line, content, UID line
         mock_imap.uid = AsyncMock(
             return_value=(
                 None,
                 [
-                    b"1 FETCH (UID 100 BODY[HEADER] {50}",
+                    b"1 FETCH (BODY[HEADER] {50}",
                     bytearray(b"From: a@test.com\r\nSubject: First\r\n\r\n"),
-                    b")",
-                    b"2 FETCH (UID 200 BODY[HEADER] {50}",
+                    b" UID 100)",
+                    b"2 FETCH (BODY[HEADER] {50}",
                     bytearray(b"From: b@test.com\r\nSubject: Second\r\n\r\n"),
-                    b")",
+                    b" UID 200)",
                     b"FETCH completed",
                 ],
             )


### PR DESCRIPTION
## Summary

- Fixes regression in `_batch_fetch_headers` introduced in PR #107 where aioimaplib response format was incorrectly assumed
- aioimaplib returns FETCH responses in 3 separate parts, but code expected UID on same line as BODY[HEADER]
- Updates test mocks to use correct response format

## Problem

PR #107 ("Batch fetch emails to reduce IMAP round trips") introduced a regression in `_batch_fetch_headers`. The function fails to parse email metadata because it assumes the UID appears on the same line as `BODY[HEADER]`, but aioimaplib returns them separately.

**Actual aioimaplib response format:**
```python
[
    b'2 FETCH (BODY[HEADER] {6149}',  # Item i:   has BODY[HEADER], NO UID
    bytearray(b'From: ...headers...'),  # Item i+1: header content
    b' UID 47)',                         # Item i+2: UID here!
]
```

**What the code expected (and tests mocked):**
```python
[
    b'1 FETCH (UID 100 BODY[HEADER] {50}',  # UID on same line - WRONG
    bytearray(b'From: ...'),
    b')',
]
```

## Fix

Updated `_batch_fetch_headers` to look for UID in `data[i + 2]` instead of `data[i]`, matching the actual aioimaplib response format.

## Test plan

- [x] Run existing tests: `uv run pytest tests/test_email_client.py tests/test_classic_handler.py -v` (43 passed)
- [x] Test mocks updated to use correct response format

🤖 Generated with [Claude Code](https://claude.com/claude-code)