### PR TITLE
fix: handle Proton Bridge IMAP response format in _batch_fetch_headers

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -343,6 +343,7 @@ class EmailClient:
         for i, item in enumerate(data):
             if not isinstance(item, bytes) or b"BODY[HEADER]" not in item:
                 continue
+            # First try to find UID in the same line (standard format)
             uid_match = re.search(rb"UID (\d+)", item)
             if uid_match and i + 1 < len(data) and isinstance(data[i + 1], bytearray):
                 uid = uid_match.group(1).decode()
@@ -350,6 +351,16 @@ class EmailClient:
                 metadata = self._parse_headers(uid, raw_headers)
                 if metadata:
                     results[uid] = metadata
+            # Proton Bridge format: UID comes AFTER header data in a separate item
+            # Format: [i]=b'N FETCH (BODY[HEADER] {size}', [i+1]=bytearray(headers), [i+2]=b' UID xxx)'
+            elif i + 2 < len(data) and isinstance(data[i + 1], bytearray):
+                uid_after_match = re.search(rb"UID (\d+)", data[i + 2]) if isinstance(data[i + 2], bytes) else None
+                if uid_after_match:
+                    uid = uid_after_match.group(1).decode()
+                    raw_headers = bytes(data[i + 1])
+                    metadata = self._parse_headers(uid, raw_headers)
+                    if metadata:
+                        results[uid] = metadata
 
         return results
 


### PR DESCRIPTION
## Summary
- Fixes Proton Bridge compatibility issue where `list_emails_metadata` returns empty emails list despite showing correct total count

## Problem
When using Proton Bridge, the IMAP FETCH response for `BODY.PEEK[HEADER]` returns the UID in a separate item *after* the header data, rather than in the same line:

**Standard format:**
- `[i] = b'N FETCH (BODY[HEADER] {size} UID xxx)'`
- `[i+1] = bytearray(headers)`

**Proton Bridge format:**
- `[i] = b'N FETCH (BODY[HEADER] {size}'`
- `[i+1] = bytearray(headers)`
- `[i+2] = b' UID xxx)'`

## Solution
Added a fallback in `_batch_fetch_headers` to check for UID in `data[i+2]` when not found in `data[i]`.

## Testing
Tested with Proton Mail Bridge v3.x on macOS. The fix is backwards-compatible with standard IMAP servers.

Related to #87