### PR TITLE
feat: add IMAP STARTTLS support with RFC 8314 security enum

### DIFF
--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -30,14 +31,76 @@ def _parse_bool_env(value: str | None, default: bool = False) -> bool:
 CONFIG_PATH = Path(os.getenv("MCP_EMAIL_SERVER_CONFIG_PATH", DEFAULT_CONFIG_PATH)).expanduser().resolve()
 
 
+class ConnectionSecurity(str, Enum):
+    """Connection security mode per RFC 8314.
+
+    - TLS: Implicit TLS — encrypted from the first byte (IMAP port 993, SMTP port 465)
+    - STARTTLS: Connect plaintext, then upgrade via STARTTLS command (IMAP port 143, SMTP port 587)
+    - NONE: No encryption (not recommended, only for trusted local connections)
+    """
+
+    TLS = "tls"
+    STARTTLS = "starttls"
+    NONE = "none"
+
+
+def _parse_security_env(value: str | None, default: ConnectionSecurity | None = None) -> ConnectionSecurity | None:
+    """Parse ConnectionSecurity from environment variable string."""
+    if value is None:
+        return default
+    try:
+        return ConnectionSecurity(value.lower())
+    except ValueError:
+        logger.warning(f"Invalid security value '{value}', using default")
+        return default
+
+
 class EmailServer(BaseModel):
     user_name: str
     password: str
     host: str
     port: int
-    use_ssl: bool = True  # Usually port 465
-    start_ssl: bool = False  # Usually port 587
+    security: ConnectionSecurity = ConnectionSecurity.TLS
     verify_ssl: bool = True  # Set to False for self-signed certificates (e.g., ProtonMail Bridge)
+
+    # Deprecated: use `security` instead. Kept for backward compatibility with existing configs.
+    use_ssl: bool | None = None
+    start_ssl: bool | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_security_from_legacy(cls, data: Any) -> Any:
+        """Derive `security` from deprecated `use_ssl`/`start_ssl` for backward compatibility.
+
+        If the new `security` field is explicitly set, it takes precedence.
+        If only legacy fields are set, `security` is derived from them.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        has_security = "security" in data
+        use_ssl = data.get("use_ssl")
+        start_ssl = data.get("start_ssl")
+
+        # Only derive from legacy fields when `security` was NOT explicitly provided
+        if not has_security and (use_ssl is not None or start_ssl is not None):
+            use_ssl_val = use_ssl if use_ssl is not None else False
+            start_ssl_val = start_ssl if start_ssl is not None else False
+
+            if use_ssl_val and start_ssl_val:
+                raise ValueError(
+                    "Invalid configuration: 'use_ssl' and 'start_ssl' cannot both be true. "
+                    "Use 'security = \"tls\"' for implicit TLS or 'security = \"starttls\"' for STARTTLS."
+                )
+
+            if use_ssl_val:
+                data["security"] = ConnectionSecurity.TLS
+            elif start_ssl_val:
+                data["security"] = ConnectionSecurity.STARTTLS
+            else:
+                data["security"] = ConnectionSecurity.NONE
+
+        return data
 
     def masked(self) -> EmailServer:
         return self.model_copy(update={"password": "********"})
@@ -101,36 +164,57 @@ class EmailSettings(AccountAttributes):
         imap_user_name: str | None = None,
         imap_password: str | None = None,
         imap_port: int = 993,
-        imap_ssl: bool = True,
+        imap_security: ConnectionSecurity = ConnectionSecurity.TLS,
+        imap_verify_ssl: bool = True,
         smtp_port: int = 465,
-        smtp_ssl: bool = True,
-        smtp_start_ssl: bool = False,
+        smtp_security: ConnectionSecurity = ConnectionSecurity.TLS,
         smtp_verify_ssl: bool = True,
         smtp_user_name: str | None = None,
         smtp_password: str | None = None,
         save_to_sent: bool = True,
         sent_folder_name: str | None = None,
+        # Deprecated parameters for backward compatibility
+        imap_ssl: bool | None = None,
+        smtp_ssl: bool | None = None,
+        smtp_start_ssl: bool | None = None,
     ) -> EmailSettings:
+        # Build incoming server config
+        incoming_kwargs: dict[str, Any] = {
+            "user_name": imap_user_name or user_name,
+            "password": imap_password or password,
+            "host": imap_host,
+            "port": imap_port,
+            "verify_ssl": imap_verify_ssl,
+        }
+        if imap_ssl is not None:
+            # Legacy path: use_ssl was explicitly passed
+            incoming_kwargs["use_ssl"] = imap_ssl
+        else:
+            incoming_kwargs["security"] = imap_security
+
+        # Build outgoing server config
+        outgoing_kwargs: dict[str, Any] = {
+            "user_name": smtp_user_name or user_name,
+            "password": smtp_password or password,
+            "host": smtp_host,
+            "port": smtp_port,
+            "verify_ssl": smtp_verify_ssl,
+        }
+        if smtp_ssl is not None or smtp_start_ssl is not None:
+            # Legacy path: use_ssl/start_ssl were explicitly passed
+            if smtp_ssl is not None:
+                outgoing_kwargs["use_ssl"] = smtp_ssl
+            if smtp_start_ssl is not None:
+                outgoing_kwargs["start_ssl"] = smtp_start_ssl
+        else:
+            outgoing_kwargs["security"] = smtp_security
+
         return cls(
             account_name=account_name,
             full_name=full_name,
             email_address=email_address,
-            incoming=EmailServer(
-                user_name=imap_user_name or user_name,
-                password=imap_password or password,
-                host=imap_host,
-                port=imap_port,
-                use_ssl=imap_ssl,
-            ),
-            outgoing=EmailServer(
-                user_name=smtp_user_name or user_name,
-                password=smtp_password or password,
-                host=smtp_host,
-                port=smtp_port,
-                use_ssl=smtp_ssl,
-                start_ssl=smtp_start_ssl,
-                verify_ssl=smtp_verify_ssl,
-            ),
+            incoming=EmailServer(**incoming_kwargs),
+            outgoing=EmailServer(**outgoing_kwargs),
             save_to_sent=save_to_sent,
             sent_folder_name=sent_folder_name,
         )
@@ -147,14 +231,19 @@ class EmailSettings(AccountAttributes):
         - MCP_EMAIL_SERVER_PASSWORD
         - MCP_EMAIL_SERVER_IMAP_HOST
         - MCP_EMAIL_SERVER_IMAP_PORT (default: 993)
-        - MCP_EMAIL_SERVER_IMAP_SSL (default: true)
+        - MCP_EMAIL_SERVER_IMAP_SECURITY (default: "tls") — "tls", "starttls", or "none"
+        - MCP_EMAIL_SERVER_IMAP_VERIFY_SSL (default: true)
         - MCP_EMAIL_SERVER_SMTP_HOST
         - MCP_EMAIL_SERVER_SMTP_PORT (default: 465)
-        - MCP_EMAIL_SERVER_SMTP_SSL (default: true)
-        - MCP_EMAIL_SERVER_SMTP_START_SSL (default: false)
+        - MCP_EMAIL_SERVER_SMTP_SECURITY (default: "tls") — "tls", "starttls", or "none"
         - MCP_EMAIL_SERVER_SMTP_VERIFY_SSL (default: true)
         - MCP_EMAIL_SERVER_SAVE_TO_SENT (default: true)
         - MCP_EMAIL_SERVER_SENT_FOLDER_NAME (default: auto-detect)
+
+        Deprecated (still supported for backward compatibility):
+        - MCP_EMAIL_SERVER_IMAP_SSL → use MCP_EMAIL_SERVER_IMAP_SECURITY instead
+        - MCP_EMAIL_SERVER_SMTP_SSL → use MCP_EMAIL_SERVER_SMTP_SECURITY instead
+        - MCP_EMAIL_SERVER_SMTP_START_SSL → use MCP_EMAIL_SERVER_SMTP_SECURITY instead
         """
         # Check if minimum required environment variables are set
         email_address = os.getenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS")
@@ -176,30 +265,66 @@ class EmailSettings(AccountAttributes):
             return None
 
         try:
-            return cls.init(
-                account_name=account_name,
-                full_name=full_name,
-                email_address=email_address,
-                user_name=user_name,
-                password=password,
-                imap_host=imap_host,
-                imap_port=int(os.getenv("MCP_EMAIL_SERVER_IMAP_PORT", "993")),
-                imap_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_SSL"), True),
-                smtp_host=smtp_host,
-                smtp_port=int(os.getenv("MCP_EMAIL_SERVER_SMTP_PORT", "465")),
-                smtp_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_SSL"), True),
-                smtp_start_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_START_SSL"), False),
-                smtp_verify_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_VERIFY_SSL"), True),
-                smtp_user_name=os.getenv("MCP_EMAIL_SERVER_SMTP_USER_NAME", user_name),
-                smtp_password=os.getenv("MCP_EMAIL_SERVER_SMTP_PASSWORD", password),
-                imap_user_name=os.getenv("MCP_EMAIL_SERVER_IMAP_USER_NAME", user_name),
-                imap_password=os.getenv("MCP_EMAIL_SERVER_IMAP_PASSWORD", password),
-                save_to_sent=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SAVE_TO_SENT"), True),
-                sent_folder_name=os.getenv("MCP_EMAIL_SERVER_SENT_FOLDER_NAME"),
-            )
+            imap_port = int(os.getenv("MCP_EMAIL_SERVER_IMAP_PORT", "993"))
+            smtp_port = int(os.getenv("MCP_EMAIL_SERVER_SMTP_PORT", "465"))
+        except ValueError as e:
+            logger.error(f"Invalid port configuration: {e}")
+            return None
+
+        init_kwargs: dict[str, Any] = {
+            "account_name": account_name,
+            "full_name": full_name,
+            "email_address": email_address,
+            "user_name": user_name,
+            "password": password,
+            "imap_host": imap_host,
+            "imap_port": imap_port,
+            "imap_verify_ssl": _parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_VERIFY_SSL"), True),
+            "smtp_host": smtp_host,
+            "smtp_port": smtp_port,
+            "smtp_verify_ssl": _parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_VERIFY_SSL"), True),
+            "smtp_user_name": os.getenv("MCP_EMAIL_SERVER_SMTP_USER_NAME", user_name),
+            "smtp_password": os.getenv("MCP_EMAIL_SERVER_SMTP_PASSWORD", password),
+            "imap_user_name": os.getenv("MCP_EMAIL_SERVER_IMAP_USER_NAME", user_name),
+            "imap_password": os.getenv("MCP_EMAIL_SERVER_IMAP_PASSWORD", password),
+            "save_to_sent": _parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SAVE_TO_SENT"), True),
+            "sent_folder_name": os.getenv("MCP_EMAIL_SERVER_SENT_FOLDER_NAME"),
+        }
+
+        cls._resolve_security_env(init_kwargs)
+
+        try:
+            return cls.init(**init_kwargs)
         except (ValueError, TypeError) as e:
             logger.error(f"Failed to create email settings from environment variables: {e}")
             return None
+
+    @staticmethod
+    def _resolve_security_env(init_kwargs: dict[str, Any]) -> None:
+        """Resolve IMAP/SMTP security from env vars, preferring new over legacy."""
+        imap_security_env = os.getenv("MCP_EMAIL_SERVER_IMAP_SECURITY")
+        smtp_security_env = os.getenv("MCP_EMAIL_SERVER_SMTP_SECURITY")
+
+        if imap_security_env is not None:
+            security = _parse_security_env(imap_security_env)
+            if security is not None:
+                init_kwargs["imap_security"] = security
+        else:
+            imap_ssl_env = os.getenv("MCP_EMAIL_SERVER_IMAP_SSL")
+            if imap_ssl_env is not None:
+                init_kwargs["imap_ssl"] = _parse_bool_env(imap_ssl_env, True)
+
+        if smtp_security_env is not None:
+            security = _parse_security_env(smtp_security_env)
+            if security is not None:
+                init_kwargs["smtp_security"] = security
+        else:
+            smtp_ssl_env = os.getenv("MCP_EMAIL_SERVER_SMTP_SSL")
+            smtp_start_ssl_env = os.getenv("MCP_EMAIL_SERVER_SMTP_START_SSL")
+            if smtp_ssl_env is not None:
+                init_kwargs["smtp_ssl"] = _parse_bool_env(smtp_ssl_env, True)
+            if smtp_start_ssl_env is not None:
+                init_kwargs["smtp_start_ssl"] = _parse_bool_env(smtp_start_ssl_env, False)
 
     def masked(self) -> EmailSettings:
         return self.model_copy(

--- a/mcp_email_server/ui.py
+++ b/mcp_email_server/ui.py
@@ -1,6 +1,6 @@
 import gradio as gr
 
-from mcp_email_server.config import EmailSettings, get_settings, store_settings
+from mcp_email_server.config import ConnectionSecurity, EmailSettings, get_settings, store_settings
 from mcp_email_server.tools.installer import install_claude_desktop, is_installed, need_update, uninstall_claude_desktop
 
 
@@ -122,7 +122,13 @@ def create_ui():  # noqa: C901
                     gr.Markdown("### IMAP Settings")
                     imap_host = gr.Textbox(label="IMAP Host", placeholder="e.g. imap.example.com")
                     imap_port = gr.Number(label="IMAP Port", value=993)
-                    imap_ssl = gr.Checkbox(label="Use SSL", value=True)
+                    imap_security = gr.Dropdown(
+                        label="Connection Security",
+                        choices=["tls", "starttls", "none"],
+                        value="tls",
+                        info="TLS (port 993) | STARTTLS (port 143) | None (not recommended)",
+                    )
+                    imap_verify_ssl = gr.Checkbox(label="Verify SSL Certificate", value=True)
                     imap_user_name = gr.Textbox(
                         label="IMAP Username (optional)", placeholder="Leave empty to use the same as above"
                     )
@@ -137,8 +143,13 @@ def create_ui():  # noqa: C901
                     gr.Markdown("### SMTP Settings")
                     smtp_host = gr.Textbox(label="SMTP Host", placeholder="e.g. smtp.example.com")
                     smtp_port = gr.Number(label="SMTP Port", value=465)
-                    smtp_ssl = gr.Checkbox(label="Use SSL", value=True)
-                    smtp_start_ssl = gr.Checkbox(label="Start SSL", value=False)
+                    smtp_security = gr.Dropdown(
+                        label="Connection Security",
+                        choices=["tls", "starttls", "none"],
+                        value="tls",
+                        info="TLS (port 465) | STARTTLS (port 587) | None (not recommended)",
+                    )
+                    smtp_verify_ssl = gr.Checkbox(label="Verify SSL Certificate", value=True)
                     smtp_user_name = gr.Textbox(
                         label="SMTP Username (optional)", placeholder="Leave empty to use the same as above"
                     )
@@ -163,13 +174,14 @@ def create_ui():  # noqa: C901
                 password,
                 imap_host,
                 imap_port,
-                imap_ssl,
+                imap_security,
+                imap_verify_ssl,
                 imap_user_name,
                 imap_password,
                 smtp_host,
                 smtp_port,
-                smtp_ssl,
-                smtp_start_ssl,
+                smtp_security,
+                smtp_verify_ssl,
                 smtp_user_name,
                 smtp_password,
             ):
@@ -190,13 +202,14 @@ def create_ui():  # noqa: C901
                             password,
                             imap_host,
                             imap_port,
-                            imap_ssl,
+                            imap_security,
+                            imap_verify_ssl,
                             imap_user_name,
                             imap_password,
                             smtp_host,
                             smtp_port,
-                            smtp_ssl,
-                            smtp_start_ssl,
+                            smtp_security,
+                            smtp_verify_ssl,
                             smtp_user_name,
                             smtp_password,
                         )
@@ -216,13 +229,14 @@ def create_ui():  # noqa: C901
                             password,
                             imap_host,
                             imap_port,
-                            imap_ssl,
+                            imap_security,
+                            imap_verify_ssl,
                             imap_user_name,
                             imap_password,
                             smtp_host,
                             smtp_port,
-                            smtp_ssl,
-                            smtp_start_ssl,
+                            smtp_security,
+                            smtp_verify_ssl,
                             smtp_user_name,
                             smtp_password,
                         )
@@ -247,13 +261,14 @@ def create_ui():  # noqa: C901
                                 password,
                                 imap_host,
                                 imap_port,
-                                imap_ssl,
+                                imap_security,
+                                imap_verify_ssl,
                                 imap_user_name,
                                 imap_password,
                                 smtp_host,
                                 smtp_port,
-                                smtp_ssl,
-                                smtp_start_ssl,
+                                smtp_security,
+                                smtp_verify_ssl,
                                 smtp_user_name,
                                 smtp_password,
                             )
@@ -268,10 +283,11 @@ def create_ui():  # noqa: C901
                         imap_host=imap_host,
                         smtp_host=smtp_host,
                         imap_port=int(imap_port),
-                        imap_ssl=imap_ssl,
+                        imap_security=ConnectionSecurity(imap_security),
+                        imap_verify_ssl=imap_verify_ssl,
                         smtp_port=int(smtp_port),
-                        smtp_ssl=smtp_ssl,
-                        smtp_start_ssl=smtp_start_ssl,
+                        smtp_security=ConnectionSecurity(smtp_security),
+                        smtp_verify_ssl=smtp_verify_ssl,
                         imap_user_name=imap_user_name if imap_user_name else None,
                         imap_password=imap_password if imap_password else None,
                         smtp_user_name=smtp_user_name if smtp_user_name else None,
@@ -300,13 +316,14 @@ def create_ui():  # noqa: C901
                         "",  # Clear password
                         "",  # Clear imap_host
                         993,  # Reset imap_port
-                        True,  # Reset imap_ssl
+                        "tls",  # Reset imap_security
+                        True,  # Reset imap_verify_ssl
                         "",  # Clear imap_user_name
                         "",  # Clear imap_password
                         "",  # Clear smtp_host
                         465,  # Reset smtp_port
-                        True,  # Reset smtp_ssl
-                        False,  # Reset smtp_start_ssl
+                        "tls",  # Reset smtp_security
+                        True,  # Reset smtp_verify_ssl
                         "",  # Clear smtp_user_name
                         "",  # Clear smtp_password
                     )
@@ -325,13 +342,14 @@ def create_ui():  # noqa: C901
                         password,
                         imap_host,
                         imap_port,
-                        imap_ssl,
+                        imap_security,
+                        imap_verify_ssl,
                         imap_user_name,
                         imap_password,
                         smtp_host,
                         smtp_port,
-                        smtp_ssl,
-                        smtp_start_ssl,
+                        smtp_security,
+                        smtp_verify_ssl,
                         smtp_user_name,
                         smtp_password,
                     )
@@ -347,13 +365,14 @@ def create_ui():  # noqa: C901
                     password,
                     imap_host,
                     imap_port,
-                    imap_ssl,
+                    imap_security,
+                    imap_verify_ssl,
                     imap_user_name,
                     imap_password,
                     smtp_host,
                     smtp_port,
-                    smtp_ssl,
-                    smtp_start_ssl,
+                    smtp_security,
+                    smtp_verify_ssl,
                     smtp_user_name,
                     smtp_password,
                 ],
@@ -369,13 +388,14 @@ def create_ui():  # noqa: C901
                     password,
                     imap_host,
                     imap_port,
-                    imap_ssl,
+                    imap_security,
+                    imap_verify_ssl,
                     imap_user_name,
                     imap_password,
                     smtp_host,
                     smtp_port,
-                    smtp_ssl,
-                    smtp_start_ssl,
+                    smtp_security,
+                    smtp_verify_ssl,
                     smtp_user_name,
                     smtp_password,
                 ],

--- a/tests/test_email_attachments.py
+++ b/tests/test_email_attachments.py
@@ -232,7 +232,7 @@ class TestDownloadAttachmentMailboxParam:
 
         # Mock _fetch_email_with_formats to return None (will raise ValueError)
         with patch.object(email_client, "_fetch_email_with_formats", return_value=None):
-            with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_connect_imap", return_value=mock_imap):
                 with pytest.raises(ValueError):
                     await email_client.download_attachment(
                         email_id="123",
@@ -246,20 +246,16 @@ class TestDownloadAttachmentMailboxParam:
     @pytest.mark.asyncio
     async def test_download_attachment_custom_mailbox(self, email_client, tmp_path):
         """Test download_attachment with custom mailbox parameter."""
-        import asyncio
 
         save_path = str(tmp_path / "attachment.pdf")
 
         mock_imap = AsyncMock()
-        mock_imap._client_task = asyncio.Future()
-        mock_imap._client_task.set_result(None)
-        mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
         mock_imap.select = AsyncMock(return_value=("OK", [b"1"]))
         mock_imap.logout = AsyncMock()
 
         with patch.object(email_client, "_fetch_email_with_formats", return_value=None):
-            with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_connect_imap", return_value=mock_imap):
                 with pytest.raises(ValueError):
                     await email_client.download_attachment(
                         email_id="123",
@@ -274,20 +270,16 @@ class TestDownloadAttachmentMailboxParam:
     @pytest.mark.asyncio
     async def test_download_attachment_special_folder(self, email_client, tmp_path):
         """Test download_attachment with special folder like [Gmail]/Sent Mail."""
-        import asyncio
 
         save_path = str(tmp_path / "attachment.pdf")
 
         mock_imap = AsyncMock()
-        mock_imap._client_task = asyncio.Future()
-        mock_imap._client_task.set_result(None)
-        mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
         mock_imap.select = AsyncMock(return_value=("OK", [b"1"]))
         mock_imap.logout = AsyncMock()
 
         with patch.object(email_client, "_fetch_email_with_formats", return_value=None):
-            with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_connect_imap", return_value=mock_imap):
                 with pytest.raises(ValueError):
                     await email_client.download_attachment(
                         email_id="123",

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -235,7 +235,7 @@ class TestEmailClient:
             },
         }
 
-        with patch.object(email_client, "imap_class", return_value=mock_imap):
+        with patch.object(email_client, "_connect_imap", return_value=mock_imap):
             with patch.object(email_client, "_batch_fetch_dates", return_value=mock_dates) as mock_fetch_dates:
                 with patch.object(
                     email_client, "_batch_fetch_headers", return_value=mock_metadata
@@ -273,7 +273,7 @@ class TestEmailClient:
         mock_imap.logout = AsyncMock()
 
         # Mock IMAP class
-        with patch.object(email_client, "imap_class", return_value=mock_imap):
+        with patch.object(email_client, "_connect_imap", return_value=mock_imap):
             count = await email_client.get_email_count()
 
             assert count == 5

--- a/tests/test_imap_starttls.py
+++ b/tests/test_imap_starttls.py
@@ -1,0 +1,452 @@
+"""Tests for IMAP STARTTLS support and ConnectionSecurity enum."""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_email_server.config import ConnectionSecurity, EmailServer, EmailSettings
+
+
+class TestConnectionSecurity:
+    """Tests for the ConnectionSecurity enum and EmailServer model."""
+
+    def test_default_security_is_tls(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993)
+        assert server.security == ConnectionSecurity.TLS
+
+    def test_explicit_security_tls(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993, security="tls")
+        assert server.security == ConnectionSecurity.TLS
+
+    def test_explicit_security_starttls(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, security="starttls")
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_explicit_security_none(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, security="none")
+        assert server.security == ConnectionSecurity.NONE
+
+    def test_legacy_use_ssl_true(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993, use_ssl=True)
+        assert server.security == ConnectionSecurity.TLS
+
+    def test_legacy_use_ssl_false_start_ssl_true(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, use_ssl=False, start_ssl=True)
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_legacy_use_ssl_false_start_ssl_false(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, use_ssl=False, start_ssl=False)
+        assert server.security == ConnectionSecurity.NONE
+
+    def test_legacy_use_ssl_false_only(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, use_ssl=False)
+        assert server.security == ConnectionSecurity.NONE
+
+    def test_legacy_start_ssl_true_only(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, start_ssl=True)
+        # use_ssl defaults to None (not set), start_ssl=True → STARTTLS
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_invalid_use_ssl_and_start_ssl_both_true(self):
+        with pytest.raises(ValueError, match="cannot both be true"):
+            EmailServer(user_name="u", password="p", host="h", port=993, use_ssl=True, start_ssl=True)
+
+    def test_security_enum_values(self):
+        assert ConnectionSecurity.TLS.value == "tls"
+        assert ConnectionSecurity.STARTTLS.value == "starttls"
+        assert ConnectionSecurity.NONE.value == "none"
+
+    def test_verify_ssl_default_true(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993)
+        assert server.verify_ssl is True
+
+    def test_verify_ssl_false(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993, verify_ssl=False)
+        assert server.verify_ssl is False
+
+    def test_masked_preserves_security(self):
+        server = EmailServer(user_name="u", password="secret", host="h", port=143, security="starttls")
+        masked = server.masked()
+        assert masked.security == ConnectionSecurity.STARTTLS
+        assert masked.password == "*" * 8
+
+
+class TestEmailSettingsInit:
+    """Tests for EmailSettings.init() with new security parameters."""
+
+    def test_init_with_security_params(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+            imap_port=143,
+            imap_security=ConnectionSecurity.STARTTLS,
+            smtp_port=587,
+            smtp_security=ConnectionSecurity.STARTTLS,
+        )
+        assert settings.incoming.security == ConnectionSecurity.STARTTLS
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_init_with_legacy_params(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+            imap_ssl=False,
+            smtp_ssl=False,
+            smtp_start_ssl=True,
+        )
+        # imap_ssl=False → use_ssl=False → security=NONE (no start_ssl for IMAP in legacy)
+        assert settings.incoming.security == ConnectionSecurity.NONE
+        # smtp_ssl=False + smtp_start_ssl=True → STARTTLS
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_init_default_is_tls(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+        )
+        assert settings.incoming.security == ConnectionSecurity.TLS
+        assert settings.outgoing.security == ConnectionSecurity.TLS
+
+    def test_init_with_verify_ssl(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="localhost",
+            smtp_host="localhost",
+            imap_verify_ssl=False,
+            smtp_verify_ssl=False,
+        )
+        assert settings.incoming.verify_ssl is False
+        assert settings.outgoing.verify_ssl is False
+
+
+class TestEmailSettingsFromEnv:
+    """Tests for EmailSettings.from_env() with new security env vars."""
+
+    def test_from_env_with_security_vars(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SECURITY", "starttls")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_SECURITY", "starttls")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_PORT", "143")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_PORT", "587")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.STARTTLS
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_from_env_with_legacy_ssl_vars(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SSL", "false")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_SSL", "false")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_START_SSL", "true")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.NONE
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_from_env_security_takes_precedence_over_legacy(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        # New env var takes precedence
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SECURITY", "starttls")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SSL", "true")  # Should be ignored
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.STARTTLS
+
+    def test_from_env_with_imap_verify_ssl(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "localhost")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "localhost")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_VERIFY_SSL", "false")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.verify_ssl is False
+
+    def test_from_env_invalid_security_value_uses_default(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SECURITY", "invalid_value")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.TLS  # Falls back to default
+
+
+class TestImapConnection:
+    """Tests for IMAP connection creation with different security modes."""
+
+    @pytest.mark.asyncio
+    async def test_create_imap_connection_tls(self):
+        server = EmailServer(user_name="u", password="p", host="localhost", port=993, security="tls")
+
+        with patch("mcp_email_server.emails.classic.aioimaplib") as mock_aioimaplib:
+            mock_imap = AsyncMock()
+            mock_imap._client_task = asyncio.Future()
+            mock_imap._client_task.set_result(None)
+            mock_imap.wait_hello_from_server = AsyncMock()
+            mock_aioimaplib.IMAP4_SSL.return_value = mock_imap
+
+            from mcp_email_server.emails.classic import _create_imap_connection
+
+            result = await _create_imap_connection(server)
+
+            mock_aioimaplib.IMAP4_SSL.assert_called_once()
+            assert result is mock_imap
+
+    @pytest.mark.asyncio
+    async def test_create_imap_connection_none(self):
+        server = EmailServer(user_name="u", password="p", host="localhost", port=143, security="none")
+
+        with patch("mcp_email_server.emails.classic.aioimaplib") as mock_aioimaplib:
+            mock_imap = AsyncMock()
+            mock_imap._client_task = asyncio.Future()
+            mock_imap._client_task.set_result(None)
+            mock_imap.wait_hello_from_server = AsyncMock()
+            mock_aioimaplib.IMAP4.return_value = mock_imap
+
+            from mcp_email_server.emails.classic import _create_imap_connection
+
+            result = await _create_imap_connection(server)
+
+            mock_aioimaplib.IMAP4.assert_called_once_with("localhost", 143)
+            assert result is mock_imap
+
+    @pytest.mark.asyncio
+    async def test_create_imap_connection_starttls(self):
+        server = EmailServer(user_name="u", password="p", host="localhost", port=143, security="starttls")
+
+        with (
+            patch("mcp_email_server.emails.classic.aioimaplib") as mock_aioimaplib,
+            patch("mcp_email_server.emails.classic._imap_starttls") as mock_starttls,
+        ):
+            mock_imap = AsyncMock()
+            mock_imap._client_task = asyncio.Future()
+            mock_imap._client_task.set_result(None)
+            mock_imap.wait_hello_from_server = AsyncMock()
+            mock_aioimaplib.IMAP4.return_value = mock_imap
+
+            from mcp_email_server.emails.classic import _create_imap_connection
+
+            result = await _create_imap_connection(server)
+
+            mock_aioimaplib.IMAP4.assert_called_once_with("localhost", 143)
+            mock_starttls.assert_called_once()
+            assert result is mock_imap
+
+
+class TestImapStarttls:
+    """Tests for the _imap_starttls function."""
+
+    @pytest.mark.asyncio
+    async def test_starttls_succeeds(self):
+        from mcp_email_server.emails.classic import _imap_starttls
+
+        mock_imap = MagicMock()
+        mock_protocol = MagicMock()
+        mock_protocol.capabilities = {"STARTTLS", "IMAP4rev1"}
+        mock_protocol.new_tag.return_value = "A001"
+        mock_protocol.loop = asyncio.get_event_loop()
+        mock_protocol.transport = MagicMock()
+
+        # Mock execute to return OK
+        mock_response = MagicMock()
+        mock_response.result = "OK"
+        mock_protocol.execute = AsyncMock(return_value=mock_response)
+        mock_protocol.capability = AsyncMock()
+
+        mock_imap.protocol = mock_protocol
+
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+        mock_tls_transport = MagicMock()
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.start_tls = AsyncMock(return_value=mock_tls_transport)
+
+            await _imap_starttls(mock_imap, ssl_ctx, "localhost")
+
+            # Verify STARTTLS command was sent
+            mock_protocol.execute.assert_called_once()
+            cmd = mock_protocol.execute.call_args[0][0]
+            assert cmd.name == "STARTTLS"
+
+            # Verify transport was upgraded
+            mock_loop.return_value.start_tls.assert_called_once()
+
+            # Verify capabilities were re-fetched
+            mock_protocol.capability.assert_called_once()
+
+            # Verify transport was replaced
+            assert mock_imap.protocol.transport is mock_tls_transport
+
+    @pytest.mark.asyncio
+    async def test_starttls_no_capability_raises(self):
+        from mcp_email_server.emails.classic import _imap_starttls
+
+        mock_imap = MagicMock()
+        mock_imap.protocol.capabilities = {"IMAP4rev1"}  # No STARTTLS
+
+        ssl_ctx = ssl.create_default_context()
+
+        with pytest.raises(OSError, match="does not advertise STARTTLS"):
+            await _imap_starttls(mock_imap, ssl_ctx, "localhost")
+
+    @pytest.mark.asyncio
+    async def test_starttls_command_fails_raises(self):
+        from mcp_email_server.emails.classic import _imap_starttls
+
+        mock_imap = MagicMock()
+        mock_protocol = MagicMock()
+        mock_protocol.capabilities = {"STARTTLS", "IMAP4rev1"}
+        mock_protocol.new_tag.return_value = "A001"
+        mock_protocol.loop = asyncio.get_event_loop()
+
+        mock_response = MagicMock()
+        mock_response.result = "NO"
+        mock_protocol.execute = AsyncMock(return_value=mock_response)
+        mock_imap.protocol = mock_protocol
+
+        ssl_ctx = ssl.create_default_context()
+
+        with pytest.raises(OSError, match="STARTTLS command failed"):
+            await _imap_starttls(mock_imap, ssl_ctx, "localhost")
+
+
+class TestEmailClientSecurity:
+    """Tests for EmailClient with different security modes."""
+
+    def test_client_tls_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=993, security="tls")
+        client = EmailClient(server)
+        assert client.smtp_use_tls is True
+        assert client.smtp_start_tls is False
+
+    def test_client_starttls_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=587, security="starttls")
+        client = EmailClient(server)
+        assert client.smtp_use_tls is False
+        assert client.smtp_start_tls is True
+
+    def test_client_none_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=25, security="none")
+        client = EmailClient(server)
+        assert client.smtp_use_tls is False
+        assert client.smtp_start_tls is False
+
+    def test_client_legacy_compat_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=587, use_ssl=False, start_ssl=True)
+        client = EmailClient(server)
+        assert client.smtp_use_tls is False
+        assert client.smtp_start_tls is True
+
+
+class TestImapSslContext:
+    """Tests for IMAP SSL context creation."""
+
+    def test_create_imap_ssl_context_verified(self):
+        from mcp_email_server.emails.classic import _create_imap_ssl_context
+
+        ctx = _create_imap_ssl_context(verify_ssl=True)
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_create_imap_ssl_context_unverified(self):
+        from mcp_email_server.emails.classic import _create_imap_ssl_context
+
+        ctx = _create_imap_ssl_context(verify_ssl=False)
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.verify_mode == ssl.CERT_NONE
+        assert ctx.check_hostname is False
+
+
+class TestTomlBackwardCompat:
+    """Tests for backward compatibility with existing TOML configs."""
+
+    def test_security_takes_precedence_over_legacy(self):
+        """When both `security` and legacy fields are set, `security` wins."""
+        server = EmailServer(user_name="u", password="p", host="h", port=993, security="starttls", use_ssl=True)
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_legacy_toml_format_incoming(self):
+        """Simulate loading a config with old use_ssl/start_ssl fields."""
+        server = EmailServer.model_validate({
+            "user_name": "user",
+            "password": "pass",
+            "host": "127.0.0.1",
+            "port": 1143,
+            "use_ssl": False,
+            "start_ssl": True,
+        })
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_new_toml_format(self):
+        """Simulate loading a config with new security field."""
+        server = EmailServer.model_validate({
+            "user_name": "user",
+            "password": "pass",
+            "host": "127.0.0.1",
+            "port": 1143,
+            "security": "starttls",
+            "verify_ssl": False,
+        })
+        assert server.security == ConnectionSecurity.STARTTLS
+        assert server.verify_ssl is False
+
+    def test_legacy_format_without_explicit_start_ssl(self):
+        """Old configs without start_ssl should default to TLS."""
+        server = EmailServer.model_validate({
+            "user_name": "user",
+            "password": "pass",
+            "host": "imap.gmail.com",
+            "port": 993,
+            "use_ssl": True,
+        })
+        assert server.security == ConnectionSecurity.TLS


### PR DESCRIPTION
## Summary

Adds proper IMAP STARTTLS support by replacing the ambiguous `use_ssl`/`start_ssl` boolean pair with a clean `ConnectionSecurity` enum (`tls`/`starttls`/`none`) per [RFC 8314](https://tools.ietf.org/html/rfc8314).

Related to #87 (Proton Mail Bridge compatibility)

## Problem

The `start_ssl` config field on `EmailServer` is only wired for SMTP, never for IMAP. When configuring `use_ssl = false` + `start_ssl = true` (e.g., Proton Mail Bridge on port 1143), the IMAP connection remains unencrypted — STARTTLS is never issued. This likely contributes to IMAP failures with Proton Bridge.

## Solution

### New `security` enum field

| Mode       | Description                                           | IMAP Port | SMTP Port |
| ---------- | ----------------------------------------------------- | --------- | --------- |
| `tls`      | Implicit TLS — encrypted from the first byte          | 993       | 465       |
| `starttls` | STARTTLS — connect plaintext, then upgrade to TLS     | 143       | 587       |
| `none`     | No encryption (not recommended)                       | 143       | 25        |

### Changes

**`config.py`:**
- Added `ConnectionSecurity` enum with RFC 8314 docstring
- Added `security` field on `EmailServer` (default: `tls`)
- `mode="before"` model validator derives `security` from legacy fields; explicit `security` takes precedence
- New env vars: `MCP_EMAIL_SERVER_IMAP_SECURITY`, `MCP_EMAIL_SERVER_SMTP_SECURITY`
- Added `imap_verify_ssl` support (was only on SMTP before)
- Extracted `_parse_security_env()` and `_resolve_security_env()` helpers

**`emails/classic.py`:**
- Implemented `_imap_starttls()` — sends STARTTLS command, upgrades transport via `asyncio.loop.start_tls()` (same pattern as aiosmtplib)
- Added `_create_imap_connection()` factory handling TLS/STARTTLS/plaintext
- Replaced all direct `imap_class()` calls with `_connect_imap()`
- Added `_create_imap_ssl_context()` for `verify_ssl=false` support

**`ui.py`:**
- Replaced `Use SSL` / `Start SSL` checkboxes with `Connection Security` dropdown (`tls`/`starttls`/`none`)
- Added `Verify SSL Certificate` checkbox for both IMAP and SMTP

**Tests:** 39 new tests covering enum, backward compat, validator precedence, STARTTLS flow, SSL context, env vars

**README:** Documented security modes, env vars, ProtonMail Bridge example

### Backward Compatibility

- Existing TOML configs with `use_ssl`/`start_ssl` continue to work unchanged
- Existing env vars still work; new `*_SECURITY` vars take precedence when set
- Default behavior unchanged (`security = "tls"`)

### ProtonMail Bridge Example

```toml
[emails.incoming]
host = "127.0.0.1"
port = 1143
security = "starttls"
verify_ssl = false

[emails.outgoing]
host = "127.0.0.1"
port = 1025
security = "starttls"
verify_ssl = false
```

## Testing

- All 172 tests pass (133 existing + 39 new)
- `make check` passes (ruff, prettier, pre-commit, deptry)
- Tested with Proton Mail Bridge v3.x on macOS
