### PR TITLE
feat: add IMAP STARTTLS support with RFC 8314 security enum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,21 @@ test: ## Test the code with pytest
 	@echo "🚀 Testing code: Running pytest"
 	@uv run python -m pytest --cov --cov-config=pyproject.toml --cov-report=xml -vv -s
 
+.PHONY: test-integration
+test-integration: ## Run integration tests (real protocol servers, no Docker)
+	@echo "🚀 Running integration tests"
+	@uv run --group integration python -m pytest -m integration -o "addopts=" -vv -s
+
+.PHONY: test-docker
+test-docker: ## Run Docker integration tests (requires Docker)
+	@echo "🐳 Running Docker integration tests"
+	@uv run --group docker python -m pytest -m docker -o "addopts=" -vv -s
+
+.PHONY: test-all
+test-all: ## Run all tests (unit + integration + Docker)
+	@echo "🚀 Running all tests"
+	@uv run --group integration --group docker python -m pytest -o "addopts=" --cov --cov-config=pyproject.toml --cov-report=xml -vv -s
+
 .PHONY: build
 build: clean-build ## Build wheel file
 	@echo "🚀 Creating wheel file"

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,25 @@ build: clean-build ## Build wheel file
 
 .PHONY: clean-build
 clean-build: ## Clean build artifacts
-	@echo "🚀 Removing build artifacts"
-	@uv run python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
+	@rm -rf dist build *.egg-info
+
+.PHONY: clean
+clean: clean-build ## Remove build, test, and cache artifacts
+	@find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	@find . -type f -name "*.py[co]" -delete 2>/dev/null || true
+	@rm -rf .pytest_cache .coverage coverage.xml htmlcov .mypy_cache .ruff_cache .hypothesis
+	@echo "✨ Clean complete"
+
+.PHONY: clean-docker
+clean-docker: ## Stop and remove Docker test containers and volumes
+	@echo "🐳 Cleaning Docker test environment"
+	@docker compose -f tests/docker/docker-compose.yml down -v --remove-orphans 2>/dev/null || true
+	@echo "✨ Docker clean complete"
+
+.PHONY: clean-all
+clean-all: clean clean-docker ## Remove all artifacts including tox, docs, and Docker
+	@rm -rf .tox .nox site
+	@echo "✨ Deep clean complete"
 
 .PHONY: publish
 publish: ## Publish a release to PyPI.

--- a/README.md
+++ b/README.md
@@ -63,24 +63,31 @@ You can also configure the email server using environment variables, which is pa
 
 #### Available Environment Variables
 
-| Variable                                      | Description                                            | Default       | Required |
-| --------------------------------------------- | ------------------------------------------------------ | ------------- | -------- |
-| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                     | `"default"`   | No       |
-| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                           | Email prefix  | No       |
-| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                          | -             | Yes      |
-| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                         | Same as email | No       |
-| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                         | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                       | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                       | `993`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_SECURITY`              | IMAP connection security: `tls`, `starttls`, or `none` | `tls`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates                           | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host                                       | -             | Yes      |
-| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                       | `465`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_SECURITY`              | SMTP connection security: `tls`, `starttls`, or `none` | `tls`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SMTP SSL certificates                           | `true`        | No       |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                             | `false`       | No       |
-| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                   | `true`        | No       |
-| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)       | -             | No       |
+| Variable                                      | TOML Key                       | Description                                            | Default                                          | Required |
+| --------------------------------------------- | ------------------------------ | ------------------------------------------------------ | ------------------------------------------------ | -------- |
+| `MCP_EMAIL_SERVER_CONFIG_PATH`                | —                              | Path to TOML config file                               | `~/.config/zerolib/mcp_email_server/config.toml` | No       |
+| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | `emails[].account_name`        | Account identifier                                     | `"default"`                                      | No       |
+| `MCP_EMAIL_SERVER_FULL_NAME`                  | `emails[].full_name`           | Display name                                           | Email prefix                                     | No       |
+| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | `emails[].email_address`       | Email address                                          | —                                                | Yes      |
+| `MCP_EMAIL_SERVER_USER_NAME`                  | `emails[].incoming.user_name`  | Login username (IMAP & SMTP)                           | Same as email                                    | No       |
+| `MCP_EMAIL_SERVER_PASSWORD`                   | `emails[].incoming.password`   | Email password (IMAP & SMTP)                           | —                                                | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_HOST`                  | `emails[].incoming.host`       | IMAP server host                                       | —                                                | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_PORT`                  | `emails[].incoming.port`       | IMAP server port                                       | `993`                                            | No       |
+| `MCP_EMAIL_SERVER_IMAP_SECURITY`              | `emails[].incoming.security`   | IMAP connection security: `tls`, `starttls`, or `none` | `tls`                                            | No       |
+| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | `emails[].incoming.verify_ssl` | Verify IMAP SSL certificates                           | `true`                                           | No       |
+| `MCP_EMAIL_SERVER_IMAP_USER_NAME`             | `emails[].incoming.user_name`  | IMAP-specific username (overrides `USER_NAME`)         | Same as `USER_NAME`                              | No       |
+| `MCP_EMAIL_SERVER_IMAP_PASSWORD`              | `emails[].incoming.password`   | IMAP-specific password (overrides `PASSWORD`)          | Same as `PASSWORD`                               | No       |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | `emails[].outgoing.host`       | SMTP server host                                       | —                                                | Yes      |
+| `MCP_EMAIL_SERVER_SMTP_PORT`                  | `emails[].outgoing.port`       | SMTP server port                                       | `465`                                            | No       |
+| `MCP_EMAIL_SERVER_SMTP_SECURITY`              | `emails[].outgoing.security`   | SMTP connection security: `tls`, `starttls`, or `none` | `tls`                                            | No       |
+| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | `emails[].outgoing.verify_ssl` | Verify SMTP SSL certificates                           | `true`                                           | No       |
+| `MCP_EMAIL_SERVER_SMTP_USER_NAME`             | `emails[].outgoing.user_name`  | SMTP-specific username (overrides `USER_NAME`)         | Same as `USER_NAME`                              | No       |
+| `MCP_EMAIL_SERVER_SMTP_PASSWORD`              | `emails[].outgoing.password`   | SMTP-specific password (overrides `PASSWORD`)          | Same as `PASSWORD`                               | No       |
+| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | `emails[].save_to_sent`        | Save sent emails to IMAP Sent folder                   | `true`                                           | No       |
+| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | `emails[].sent_folder_name`    | Custom Sent folder name (auto-detect if not set)       | —                                                | No       |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | `enable_attachment_download`   | Enable attachment download                             | `false`                                          | No       |
+
+> **Note:** The `emails[].` prefix corresponds to `[[emails]]` in TOML (array of tables). See [TOML Configuration Reference](#toml-configuration-reference) for the full config structure.
 
 > **Deprecated:** `MCP_EMAIL_SERVER_IMAP_SSL`, `MCP_EMAIL_SERVER_SMTP_SSL`, and `MCP_EMAIL_SERVER_SMTP_START_SSL` still work for backward compatibility but are superseded by the `*_SECURITY` variables above.
 
@@ -93,6 +100,99 @@ The `security` field (or `*_SECURITY` env var) controls how the connection to th
 | `tls`      | **Implicit TLS** — encrypted from the first byte      | 993       | 465       |
 | `starttls` | **STARTTLS** — connect plaintext, then upgrade to TLS | 143       | 587       |
 | `none`     | **No encryption** — plaintext only (not recommended)  | 143       | 25        |
+
+### TOML Configuration Reference
+
+The configuration file is located at `~/.config/zerolib/mcp_email_server/config.toml` by default (override with `MCP_EMAIL_SERVER_CONFIG_PATH`). You can also configure settings via the UI: `uvx mcp-email-server@latest ui`
+
+#### Single Account
+
+```toml
+# Global settings
+enable_attachment_download = false  # Set to true to allow attachment downloads
+
+# Email account — use [[emails]] for each account
+[[emails]]
+account_name = "work"
+full_name = "John Doe"
+email_address = "john@example.com"
+save_to_sent = true              # Save sent emails to IMAP Sent folder
+# sent_folder_name = "Sent"     # Optional: override auto-detected Sent folder name
+
+# IMAP (incoming mail)
+[emails.incoming]
+host = "imap.gmail.com"
+port = 993
+user_name = "john@example.com"
+password = "your-app-password"
+security = "tls"                 # "tls" (default) | "starttls" | "none"
+verify_ssl = true                # Set to false for self-signed certificates
+
+# SMTP (outgoing mail)
+[emails.outgoing]
+host = "smtp.gmail.com"
+port = 465
+user_name = "john@example.com"
+password = "your-app-password"
+security = "tls"                 # "tls" (default) | "starttls" | "none"
+verify_ssl = true                # Set to false for self-signed certificates
+```
+
+#### Multiple Accounts
+
+Add multiple `[[emails]]` blocks to configure several email accounts. Each account has its own IMAP/SMTP settings and can use different security modes:
+
+```toml
+enable_attachment_download = true
+
+# Account 1: Work Gmail (Implicit TLS)
+[[emails]]
+account_name = "work"
+full_name = "John Doe"
+email_address = "john@company.com"
+save_to_sent = true
+
+[emails.incoming]
+host = "imap.gmail.com"
+port = 993
+user_name = "john@company.com"
+password = "gmail-app-password"
+security = "tls"
+verify_ssl = true
+
+[emails.outgoing]
+host = "smtp.gmail.com"
+port = 465
+user_name = "john@company.com"
+password = "gmail-app-password"
+security = "tls"
+verify_ssl = true
+
+# Account 2: Personal ProtonMail via Bridge (STARTTLS + self-signed certs)
+[[emails]]
+account_name = "personal"
+full_name = "John Doe"
+email_address = "john@proton.me"
+save_to_sent = true
+
+[emails.incoming]
+host = "127.0.0.1"
+port = 1143
+user_name = "john@proton.me"
+password = "bridge-password"
+security = "starttls"
+verify_ssl = false
+
+[emails.outgoing]
+host = "127.0.0.1"
+port = 1025
+user_name = "john@proton.me"
+password = "bridge-password"
+security = "starttls"
+verify_ssl = false
+```
+
+> **Tip:** Use `account_name` to distinguish accounts when calling MCP tools (e.g., `get_emails(account_name="work")`).
 
 ### Enabling Attachment Downloads
 

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -30,14 +31,76 @@ def _parse_bool_env(value: str | None, default: bool = False) -> bool:
 CONFIG_PATH = Path(os.getenv("MCP_EMAIL_SERVER_CONFIG_PATH", DEFAULT_CONFIG_PATH)).expanduser().resolve()
 
 
+class ConnectionSecurity(str, Enum):
+    """Connection security mode per RFC 8314.
+
+    - TLS: Implicit TLS — encrypted from the first byte (IMAP port 993, SMTP port 465)
+    - STARTTLS: Connect plaintext, then upgrade via STARTTLS command (IMAP port 143, SMTP port 587)
+    - NONE: No encryption (not recommended, only for trusted local connections)
+    """
+
+    TLS = "tls"
+    STARTTLS = "starttls"
+    NONE = "none"
+
+
+def _parse_security_env(value: str | None, default: ConnectionSecurity | None = None) -> ConnectionSecurity | None:
+    """Parse ConnectionSecurity from environment variable string."""
+    if value is None:
+        return default
+    try:
+        return ConnectionSecurity(value.lower())
+    except ValueError:
+        logger.warning(f"Invalid security value '{value}', using default")
+        return default
+
+
 class EmailServer(BaseModel):
     user_name: str
     password: str
     host: str
     port: int
-    use_ssl: bool = True  # Usually port 465
-    start_ssl: bool = False  # Usually port 587
+    security: ConnectionSecurity = ConnectionSecurity.TLS
     verify_ssl: bool = True  # Set to False for self-signed certificates (e.g., ProtonMail Bridge)
+
+    # Deprecated: use `security` instead. Kept for backward compatibility with existing configs.
+    use_ssl: bool | None = None
+    start_ssl: bool | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_security_from_legacy(cls, data: Any) -> Any:
+        """Derive `security` from deprecated `use_ssl`/`start_ssl` for backward compatibility.
+
+        If the new `security` field is explicitly set, it takes precedence.
+        If only legacy fields are set, `security` is derived from them.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        has_security = "security" in data
+        use_ssl = data.get("use_ssl")
+        start_ssl = data.get("start_ssl")
+
+        # Only derive from legacy fields when `security` was NOT explicitly provided
+        if not has_security and (use_ssl is not None or start_ssl is not None):
+            use_ssl_val = use_ssl if use_ssl is not None else False
+            start_ssl_val = start_ssl if start_ssl is not None else False
+
+            if use_ssl_val and start_ssl_val:
+                raise ValueError(
+                    "Invalid configuration: 'use_ssl' and 'start_ssl' cannot both be true. "
+                    "Use 'security = \"tls\"' for implicit TLS or 'security = \"starttls\"' for STARTTLS."
+                )
+
+            if use_ssl_val:
+                data["security"] = ConnectionSecurity.TLS
+            elif start_ssl_val:
+                data["security"] = ConnectionSecurity.STARTTLS
+            else:
+                data["security"] = ConnectionSecurity.NONE
+
+        return data
 
     def masked(self) -> EmailServer:
         return self.model_copy(update={"password": "********"})
@@ -101,36 +164,57 @@ class EmailSettings(AccountAttributes):
         imap_user_name: str | None = None,
         imap_password: str | None = None,
         imap_port: int = 993,
-        imap_ssl: bool = True,
+        imap_security: ConnectionSecurity = ConnectionSecurity.TLS,
+        imap_verify_ssl: bool = True,
         smtp_port: int = 465,
-        smtp_ssl: bool = True,
-        smtp_start_ssl: bool = False,
+        smtp_security: ConnectionSecurity = ConnectionSecurity.TLS,
         smtp_verify_ssl: bool = True,
         smtp_user_name: str | None = None,
         smtp_password: str | None = None,
         save_to_sent: bool = True,
         sent_folder_name: str | None = None,
+        # Deprecated parameters for backward compatibility
+        imap_ssl: bool | None = None,
+        smtp_ssl: bool | None = None,
+        smtp_start_ssl: bool | None = None,
     ) -> EmailSettings:
+        # Build incoming server config
+        incoming_kwargs: dict[str, Any] = {
+            "user_name": imap_user_name or user_name,
+            "password": imap_password or password,
+            "host": imap_host,
+            "port": imap_port,
+            "verify_ssl": imap_verify_ssl,
+        }
+        if imap_ssl is not None:
+            # Legacy path: use_ssl was explicitly passed
+            incoming_kwargs["use_ssl"] = imap_ssl
+        else:
+            incoming_kwargs["security"] = imap_security
+
+        # Build outgoing server config
+        outgoing_kwargs: dict[str, Any] = {
+            "user_name": smtp_user_name or user_name,
+            "password": smtp_password or password,
+            "host": smtp_host,
+            "port": smtp_port,
+            "verify_ssl": smtp_verify_ssl,
+        }
+        if smtp_ssl is not None or smtp_start_ssl is not None:
+            # Legacy path: use_ssl/start_ssl were explicitly passed
+            if smtp_ssl is not None:
+                outgoing_kwargs["use_ssl"] = smtp_ssl
+            if smtp_start_ssl is not None:
+                outgoing_kwargs["start_ssl"] = smtp_start_ssl
+        else:
+            outgoing_kwargs["security"] = smtp_security
+
         return cls(
             account_name=account_name,
             full_name=full_name,
             email_address=email_address,
-            incoming=EmailServer(
-                user_name=imap_user_name or user_name,
-                password=imap_password or password,
-                host=imap_host,
-                port=imap_port,
-                use_ssl=imap_ssl,
-            ),
-            outgoing=EmailServer(
-                user_name=smtp_user_name or user_name,
-                password=smtp_password or password,
-                host=smtp_host,
-                port=smtp_port,
-                use_ssl=smtp_ssl,
-                start_ssl=smtp_start_ssl,
-                verify_ssl=smtp_verify_ssl,
-            ),
+            incoming=EmailServer(**incoming_kwargs),
+            outgoing=EmailServer(**outgoing_kwargs),
             save_to_sent=save_to_sent,
             sent_folder_name=sent_folder_name,
         )
@@ -147,14 +231,19 @@ class EmailSettings(AccountAttributes):
         - MCP_EMAIL_SERVER_PASSWORD
         - MCP_EMAIL_SERVER_IMAP_HOST
         - MCP_EMAIL_SERVER_IMAP_PORT (default: 993)
-        - MCP_EMAIL_SERVER_IMAP_SSL (default: true)
+        - MCP_EMAIL_SERVER_IMAP_SECURITY (default: "tls") — "tls", "starttls", or "none"
+        - MCP_EMAIL_SERVER_IMAP_VERIFY_SSL (default: true)
         - MCP_EMAIL_SERVER_SMTP_HOST
         - MCP_EMAIL_SERVER_SMTP_PORT (default: 465)
-        - MCP_EMAIL_SERVER_SMTP_SSL (default: true)
-        - MCP_EMAIL_SERVER_SMTP_START_SSL (default: false)
+        - MCP_EMAIL_SERVER_SMTP_SECURITY (default: "tls") — "tls", "starttls", or "none"
         - MCP_EMAIL_SERVER_SMTP_VERIFY_SSL (default: true)
         - MCP_EMAIL_SERVER_SAVE_TO_SENT (default: true)
         - MCP_EMAIL_SERVER_SENT_FOLDER_NAME (default: auto-detect)
+
+        Deprecated (still supported for backward compatibility):
+        - MCP_EMAIL_SERVER_IMAP_SSL → use MCP_EMAIL_SERVER_IMAP_SECURITY instead
+        - MCP_EMAIL_SERVER_SMTP_SSL → use MCP_EMAIL_SERVER_SMTP_SECURITY instead
+        - MCP_EMAIL_SERVER_SMTP_START_SSL → use MCP_EMAIL_SERVER_SMTP_SECURITY instead
         """
         # Check if minimum required environment variables are set
         email_address = os.getenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS")
@@ -176,30 +265,66 @@ class EmailSettings(AccountAttributes):
             return None
 
         try:
-            return cls.init(
-                account_name=account_name,
-                full_name=full_name,
-                email_address=email_address,
-                user_name=user_name,
-                password=password,
-                imap_host=imap_host,
-                imap_port=int(os.getenv("MCP_EMAIL_SERVER_IMAP_PORT", "993")),
-                imap_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_SSL"), True),
-                smtp_host=smtp_host,
-                smtp_port=int(os.getenv("MCP_EMAIL_SERVER_SMTP_PORT", "465")),
-                smtp_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_SSL"), True),
-                smtp_start_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_START_SSL"), False),
-                smtp_verify_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_VERIFY_SSL"), True),
-                smtp_user_name=os.getenv("MCP_EMAIL_SERVER_SMTP_USER_NAME", user_name),
-                smtp_password=os.getenv("MCP_EMAIL_SERVER_SMTP_PASSWORD", password),
-                imap_user_name=os.getenv("MCP_EMAIL_SERVER_IMAP_USER_NAME", user_name),
-                imap_password=os.getenv("MCP_EMAIL_SERVER_IMAP_PASSWORD", password),
-                save_to_sent=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SAVE_TO_SENT"), True),
-                sent_folder_name=os.getenv("MCP_EMAIL_SERVER_SENT_FOLDER_NAME"),
-            )
+            imap_port = int(os.getenv("MCP_EMAIL_SERVER_IMAP_PORT", "993"))
+            smtp_port = int(os.getenv("MCP_EMAIL_SERVER_SMTP_PORT", "465"))
+        except ValueError as e:
+            logger.error(f"Invalid port configuration: {e}")
+            return None
+
+        init_kwargs: dict[str, Any] = {
+            "account_name": account_name,
+            "full_name": full_name,
+            "email_address": email_address,
+            "user_name": user_name,
+            "password": password,
+            "imap_host": imap_host,
+            "imap_port": imap_port,
+            "imap_verify_ssl": _parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_VERIFY_SSL"), True),
+            "smtp_host": smtp_host,
+            "smtp_port": smtp_port,
+            "smtp_verify_ssl": _parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SMTP_VERIFY_SSL"), True),
+            "smtp_user_name": os.getenv("MCP_EMAIL_SERVER_SMTP_USER_NAME", user_name),
+            "smtp_password": os.getenv("MCP_EMAIL_SERVER_SMTP_PASSWORD", password),
+            "imap_user_name": os.getenv("MCP_EMAIL_SERVER_IMAP_USER_NAME", user_name),
+            "imap_password": os.getenv("MCP_EMAIL_SERVER_IMAP_PASSWORD", password),
+            "save_to_sent": _parse_bool_env(os.getenv("MCP_EMAIL_SERVER_SAVE_TO_SENT"), True),
+            "sent_folder_name": os.getenv("MCP_EMAIL_SERVER_SENT_FOLDER_NAME"),
+        }
+
+        cls._resolve_security_env(init_kwargs)
+
+        try:
+            return cls.init(**init_kwargs)
         except (ValueError, TypeError) as e:
             logger.error(f"Failed to create email settings from environment variables: {e}")
             return None
+
+    @staticmethod
+    def _resolve_security_env(init_kwargs: dict[str, Any]) -> None:
+        """Resolve IMAP/SMTP security from env vars, preferring new over legacy."""
+        imap_security_env = os.getenv("MCP_EMAIL_SERVER_IMAP_SECURITY")
+        smtp_security_env = os.getenv("MCP_EMAIL_SERVER_SMTP_SECURITY")
+
+        if imap_security_env is not None:
+            security = _parse_security_env(imap_security_env)
+            if security is not None:
+                init_kwargs["imap_security"] = security
+        else:
+            imap_ssl_env = os.getenv("MCP_EMAIL_SERVER_IMAP_SSL")
+            if imap_ssl_env is not None:
+                init_kwargs["imap_ssl"] = _parse_bool_env(imap_ssl_env, True)
+
+        if smtp_security_env is not None:
+            security = _parse_security_env(smtp_security_env)
+            if security is not None:
+                init_kwargs["smtp_security"] = security
+        else:
+            smtp_ssl_env = os.getenv("MCP_EMAIL_SERVER_SMTP_SSL")
+            smtp_start_ssl_env = os.getenv("MCP_EMAIL_SERVER_SMTP_START_SSL")
+            if smtp_ssl_env is not None:
+                init_kwargs["smtp_ssl"] = _parse_bool_env(smtp_ssl_env, True)
+            if smtp_start_ssl_env is not None:
+                init_kwargs["smtp_start_ssl"] = _parse_bool_env(smtp_start_ssl_env, False)
 
     def masked(self) -> EmailSettings:
         return self.model_copy(

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -97,8 +97,10 @@ class EmailServer(BaseModel):
                 data["security"] = ConnectionSecurity.TLS
             elif start_ssl_val:
                 data["security"] = ConnectionSecurity.STARTTLS
-            else:
+            elif use_ssl is False and start_ssl is False:
+                # Only disable encryption when BOTH are explicitly set to False
                 data["security"] = ConnectionSecurity.NONE
+            # Otherwise, leave security at its default (TLS) for safety
 
         return data
 

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -386,6 +386,10 @@ class Settings(BaseSettings):
         """Use re-assigned for validation to work."""
         self.emails = [email, *self.emails]
 
+    def update_email(self, email: EmailSettings) -> None:
+        """Replace an existing email account by account_name (delete + add)."""
+        self.emails = [email if e.account_name == email.account_name else e for e in self.emails]
+
     def add_provider(self, provider: ProviderSettings) -> None:
         """Use re-assigned for validation to work."""
         self.providers = [provider, *self.providers]

--- a/mcp_email_server/ui.py
+++ b/mcp_email_server/ui.py
@@ -1,6 +1,6 @@
 import gradio as gr
 
-from mcp_email_server.config import EmailSettings, get_settings, store_settings
+from mcp_email_server.config import ConnectionSecurity, EmailSettings, get_settings, store_settings
 from mcp_email_server.tools.installer import install_claude_desktop, is_installed, need_update, uninstall_claude_desktop
 
 
@@ -122,7 +122,13 @@ def create_ui():  # noqa: C901
                     gr.Markdown("### IMAP Settings")
                     imap_host = gr.Textbox(label="IMAP Host", placeholder="e.g. imap.example.com")
                     imap_port = gr.Number(label="IMAP Port", value=993)
-                    imap_ssl = gr.Checkbox(label="Use SSL", value=True)
+                    imap_security = gr.Dropdown(
+                        label="Connection Security",
+                        choices=["tls", "starttls", "none"],
+                        value="tls",
+                        info="TLS (port 993) | STARTTLS (port 143) | None (not recommended)",
+                    )
+                    imap_verify_ssl = gr.Checkbox(label="Verify SSL Certificate", value=True)
                     imap_user_name = gr.Textbox(
                         label="IMAP Username (optional)", placeholder="Leave empty to use the same as above"
                     )
@@ -137,8 +143,13 @@ def create_ui():  # noqa: C901
                     gr.Markdown("### SMTP Settings")
                     smtp_host = gr.Textbox(label="SMTP Host", placeholder="e.g. smtp.example.com")
                     smtp_port = gr.Number(label="SMTP Port", value=465)
-                    smtp_ssl = gr.Checkbox(label="Use SSL", value=True)
-                    smtp_start_ssl = gr.Checkbox(label="Start SSL", value=False)
+                    smtp_security = gr.Dropdown(
+                        label="Connection Security",
+                        choices=["tls", "starttls", "none"],
+                        value="tls",
+                        info="TLS (port 465) | STARTTLS (port 587) | None (not recommended)",
+                    )
+                    smtp_verify_ssl = gr.Checkbox(label="Verify SSL Certificate", value=True)
                     smtp_user_name = gr.Textbox(
                         label="SMTP Username (optional)", placeholder="Leave empty to use the same as above"
                     )
@@ -163,13 +174,14 @@ def create_ui():  # noqa: C901
                 password,
                 imap_host,
                 imap_port,
-                imap_ssl,
+                imap_security,
+                imap_verify_ssl,
                 imap_user_name,
                 imap_password,
                 smtp_host,
                 smtp_port,
-                smtp_ssl,
-                smtp_start_ssl,
+                smtp_security,
+                smtp_verify_ssl,
                 smtp_user_name,
                 smtp_password,
             ):
@@ -190,13 +202,14 @@ def create_ui():  # noqa: C901
                             password,
                             imap_host,
                             imap_port,
-                            imap_ssl,
+                            imap_security,
+                            imap_verify_ssl,
                             imap_user_name,
                             imap_password,
                             smtp_host,
                             smtp_port,
-                            smtp_ssl,
-                            smtp_start_ssl,
+                            smtp_security,
+                            smtp_verify_ssl,
                             smtp_user_name,
                             smtp_password,
                         )
@@ -216,13 +229,14 @@ def create_ui():  # noqa: C901
                             password,
                             imap_host,
                             imap_port,
-                            imap_ssl,
+                            imap_security,
+                            imap_verify_ssl,
                             imap_user_name,
                             imap_password,
                             smtp_host,
                             smtp_port,
-                            smtp_ssl,
-                            smtp_start_ssl,
+                            smtp_security,
+                            smtp_verify_ssl,
                             smtp_user_name,
                             smtp_password,
                         )
@@ -247,13 +261,14 @@ def create_ui():  # noqa: C901
                                 password,
                                 imap_host,
                                 imap_port,
-                                imap_ssl,
+                                imap_security,
+                                imap_verify_ssl,
                                 imap_user_name,
                                 imap_password,
                                 smtp_host,
                                 smtp_port,
-                                smtp_ssl,
-                                smtp_start_ssl,
+                                smtp_security,
+                                smtp_verify_ssl,
                                 smtp_user_name,
                                 smtp_password,
                             )
@@ -268,10 +283,11 @@ def create_ui():  # noqa: C901
                         imap_host=imap_host,
                         smtp_host=smtp_host,
                         imap_port=int(imap_port),
-                        imap_ssl=imap_ssl,
+                        imap_security=ConnectionSecurity(imap_security),
+                        imap_verify_ssl=imap_verify_ssl,
                         smtp_port=int(smtp_port),
-                        smtp_ssl=smtp_ssl,
-                        smtp_start_ssl=smtp_start_ssl,
+                        smtp_security=ConnectionSecurity(smtp_security),
+                        smtp_verify_ssl=smtp_verify_ssl,
                         imap_user_name=imap_user_name if imap_user_name else None,
                         imap_password=imap_password if imap_password else None,
                         smtp_user_name=smtp_user_name if smtp_user_name else None,
@@ -300,13 +316,14 @@ def create_ui():  # noqa: C901
                         "",  # Clear password
                         "",  # Clear imap_host
                         993,  # Reset imap_port
-                        True,  # Reset imap_ssl
+                        "tls",  # Reset imap_security
+                        True,  # Reset imap_verify_ssl
                         "",  # Clear imap_user_name
                         "",  # Clear imap_password
                         "",  # Clear smtp_host
                         465,  # Reset smtp_port
-                        True,  # Reset smtp_ssl
-                        False,  # Reset smtp_start_ssl
+                        "tls",  # Reset smtp_security
+                        True,  # Reset smtp_verify_ssl
                         "",  # Clear smtp_user_name
                         "",  # Clear smtp_password
                     )
@@ -325,13 +342,14 @@ def create_ui():  # noqa: C901
                         password,
                         imap_host,
                         imap_port,
-                        imap_ssl,
+                        imap_security,
+                        imap_verify_ssl,
                         imap_user_name,
                         imap_password,
                         smtp_host,
                         smtp_port,
-                        smtp_ssl,
-                        smtp_start_ssl,
+                        smtp_security,
+                        smtp_verify_ssl,
                         smtp_user_name,
                         smtp_password,
                     )
@@ -347,13 +365,14 @@ def create_ui():  # noqa: C901
                     password,
                     imap_host,
                     imap_port,
-                    imap_ssl,
+                    imap_security,
+                    imap_verify_ssl,
                     imap_user_name,
                     imap_password,
                     smtp_host,
                     smtp_port,
-                    smtp_ssl,
-                    smtp_start_ssl,
+                    smtp_security,
+                    smtp_verify_ssl,
                     smtp_user_name,
                     smtp_password,
                 ],
@@ -369,13 +388,14 @@ def create_ui():  # noqa: C901
                     password,
                     imap_host,
                     imap_port,
-                    imap_ssl,
+                    imap_security,
+                    imap_verify_ssl,
                     imap_user_name,
                     imap_password,
                     smtp_host,
                     smtp_port,
-                    smtp_ssl,
-                    smtp_start_ssl,
+                    smtp_security,
+                    smtp_verify_ssl,
                     smtp_user_name,
                     smtp_password,
                 ],

--- a/mcp_email_server/ui.py
+++ b/mcp_email_server/ui.py
@@ -138,6 +138,13 @@ def create_ui():  # noqa: C901
                         placeholder="Leave empty to use the same as above",
                     )
 
+                    # Auto-update IMAP port when security mode changes
+                    def update_imap_port(security):
+                        port_map = {"tls": 993, "starttls": 143, "none": 143}
+                        return port_map.get(security, 993)
+
+                    imap_security.change(fn=update_imap_port, inputs=[imap_security], outputs=[imap_port])
+
                 # SMTP settings
                 with gr.Column():
                     gr.Markdown("### SMTP Settings")
@@ -158,6 +165,13 @@ def create_ui():  # noqa: C901
                         type="password",
                         placeholder="Leave empty to use the same as above",
                     )
+
+                    # Auto-update SMTP port when security mode changes
+                    def update_smtp_port(security):
+                        port_map = {"tls": 465, "starttls": 587, "none": 25}
+                        return port_map.get(security, 465)
+
+                    smtp_security.change(fn=update_smtp_port, inputs=[smtp_security], outputs=[smtp_port])
 
             # Status message
             status_message = gr.Markdown("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,12 @@ dev = [
     "mkdocstrings[python]>=0.26.1",
 ]
 integration = [
-    "pytest-localserver>=0.9.0",
-    "aiosmtpd>=1.4.0",
+    "pytest-localserver>=0.10.0",
+    "aiosmtpd>=1.4.6",
+    "cryptography>=44.0.0",
 ]
 docker = [
-    "pytest-docker>=3.1.0",
+    "pytest-docker>=3.2.5",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,13 @@ dev = [
     "mkdocs-material>=8.5.10",
     "mkdocstrings[python]>=0.26.1",
 ]
+integration = [
+    "pytest-localserver>=0.9.0",
+    "aiosmtpd>=1.4.0",
+]
+docker = [
+    "pytest-docker>=3.1.0",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -114,6 +121,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "S106", "SIM117"]
+"tests/**/*" = ["S101", "S106", "SIM117"]
 "tests/conftest.py" = ["E402"]
 
 [tool.ruff.format]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
 # pytest.ini
 [pytest]
 asyncio_mode = auto
-# asyncio_default_fixture_loop_scope =
+# Default: only unit tests (integration/docker excluded)
+addopts = -m "not integration and not docker"
+markers =
+    integration: tests against real protocol servers (pytest-localserver + MockImapServer, no Docker)
+    docker: tests requiring Docker (GreenMail container, full SMTP→IMAP roundtrip)

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -1,7 +1,12 @@
 """Fixtures for Docker-based integration tests (Tier 2).
 
-GreenMail provides a real SMTP+IMAP server for full send→read roundtrip tests.
+GreenMail provides a real SMTP+IMAP server for full send/read roundtrip tests.
 Tests auto-skip if Docker is not available.
+
+Security modes tested:
+- NONE:     SMTP port 3025, IMAP port 3143 (plaintext)
+- TLS:      SMTPS port 3465, IMAPS port 3993 (Implicit TLS, self-signed)
+- STARTTLS: skipped (greenmail#135 — GreenMail does not support STARTTLS)
 """
 
 from __future__ import annotations
@@ -20,6 +25,8 @@ GREENMAIL_PASSWORD = "testpass"  # noqa: S105
 
 GREENMAIL_SMTP_PORT = 3025
 GREENMAIL_IMAP_PORT = 3143
+GREENMAIL_SMTPS_PORT = 3465
+GREENMAIL_IMAPS_PORT = 3993
 
 
 def pytest_collection_modifyitems(config, items):
@@ -59,6 +66,12 @@ def _greenmail_is_ready() -> bool:
         # Test IMAP socket
         with socket.create_connection(("127.0.0.1", GREENMAIL_IMAP_PORT), timeout=3):
             pass
+        # Test SMTPS socket (TLS port)
+        with socket.create_connection(("127.0.0.1", GREENMAIL_SMTPS_PORT), timeout=3):
+            pass
+        # Test IMAPS socket (TLS port)
+        with socket.create_connection(("127.0.0.1", GREENMAIL_IMAPS_PORT), timeout=3):
+            pass
         return True
     except Exception:
         return False
@@ -77,14 +90,21 @@ def greenmail(docker_services):
         "smtp_port": GREENMAIL_SMTP_PORT,
         "imap_host": "127.0.0.1",
         "imap_port": GREENMAIL_IMAP_PORT,
+        "smtps_port": GREENMAIL_SMTPS_PORT,
+        "imaps_port": GREENMAIL_IMAPS_PORT,
         "user": GREENMAIL_USER,
         "password": GREENMAIL_PASSWORD,
     }
 
 
+# ---------------------------------------------------------------------------
+# Plaintext (NONE) fixtures
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture()
 def greenmail_smtp_server(greenmail) -> EmailServer:
-    """EmailServer config for GreenMail SMTP."""
+    """EmailServer config for GreenMail SMTP (plaintext)."""
     return EmailServer(
         host=greenmail["smtp_host"],
         port=greenmail["smtp_port"],
@@ -97,7 +117,7 @@ def greenmail_smtp_server(greenmail) -> EmailServer:
 
 @pytest.fixture()
 def greenmail_imap_server(greenmail) -> EmailServer:
-    """EmailServer config for GreenMail IMAP."""
+    """EmailServer config for GreenMail IMAP (plaintext)."""
     return EmailServer(
         host=greenmail["imap_host"],
         port=greenmail["imap_port"],
@@ -110,11 +130,105 @@ def greenmail_imap_server(greenmail) -> EmailServer:
 
 @pytest.fixture()
 def greenmail_smtp_client(greenmail_smtp_server) -> EmailClient:
-    """EmailClient wired to GreenMail SMTP."""
+    """EmailClient wired to GreenMail SMTP (plaintext)."""
     return EmailClient(greenmail_smtp_server, sender=GREENMAIL_USER)
 
 
 @pytest.fixture()
 def greenmail_imap_client(greenmail_imap_server) -> EmailClient:
-    """EmailClient wired to GreenMail IMAP."""
+    """EmailClient wired to GreenMail IMAP (plaintext)."""
     return EmailClient(greenmail_imap_server, sender=GREENMAIL_USER)
+
+
+# ---------------------------------------------------------------------------
+# Implicit TLS fixtures (SMTPS / IMAPS)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def greenmail_smtps_server(greenmail) -> EmailServer:
+    """EmailServer config for GreenMail SMTPS (Implicit TLS)."""
+    return EmailServer(
+        host=greenmail["smtp_host"],
+        port=greenmail["smtps_port"],
+        user_name=greenmail["user"],
+        password=greenmail["password"],
+        security=ConnectionSecurity.TLS,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def greenmail_imaps_server(greenmail) -> EmailServer:
+    """EmailServer config for GreenMail IMAPS (Implicit TLS)."""
+    return EmailServer(
+        host=greenmail["imap_host"],
+        port=greenmail["imaps_port"],
+        user_name=greenmail["user"],
+        password=greenmail["password"],
+        security=ConnectionSecurity.TLS,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def greenmail_smtps_client(greenmail_smtps_server) -> EmailClient:
+    """EmailClient wired to GreenMail SMTPS (Implicit TLS)."""
+    return EmailClient(greenmail_smtps_server, sender=GREENMAIL_USER)
+
+
+@pytest.fixture()
+def greenmail_imaps_client(greenmail_imaps_server) -> EmailClient:
+    """EmailClient wired to GreenMail IMAPS (Implicit TLS)."""
+    return EmailClient(greenmail_imaps_server, sender=GREENMAIL_USER)
+
+
+# Note: GreenMail does not support STARTTLS on plaintext ports.
+# See https://github.com/greenmail-mail-test/greenmail/issues/135
+# STARTTLS is tested at Tier 1 (SMTP via aiosmtpd) and unit tests (IMAP).
+
+
+# ---------------------------------------------------------------------------
+# STARTTLS fixtures (upgrade on plaintext ports)
+# TODO(greenmail#135): GreenMail does not advertise STARTTLS on plaintext ports.
+# These fixtures are kept for when GreenMail adds STARTTLS support.
+# See: https://github.com/greenmail-mail-test/greenmail/issues/135
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def greenmail_smtp_starttls_server(greenmail) -> EmailServer:
+    """EmailServer config for GreenMail SMTP with STARTTLS."""
+    return EmailServer(
+        host=greenmail["smtp_host"],
+        port=greenmail["smtp_port"],
+        user_name=greenmail["user"],
+        password=greenmail["password"],
+        security=ConnectionSecurity.STARTTLS,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def greenmail_imap_starttls_server(greenmail) -> EmailServer:
+    """EmailServer config for GreenMail IMAP with STARTTLS."""
+    return EmailServer(
+        host=greenmail["imap_host"],
+        port=greenmail["imap_port"],
+        user_name=greenmail["user"],
+        password=greenmail["password"],
+        security=ConnectionSecurity.STARTTLS,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def greenmail_smtp_starttls_client(greenmail_smtp_starttls_server) -> EmailClient:
+    """EmailClient wired to GreenMail SMTP with STARTTLS."""
+    return EmailClient(greenmail_smtp_starttls_server, sender=GREENMAIL_USER)
+
+
+@pytest.fixture()
+def greenmail_imap_starttls_client(greenmail_imap_starttls_server) -> EmailClient:
+    """EmailClient wired to GreenMail IMAP with STARTTLS."""
+    return EmailClient(greenmail_imap_starttls_server, sender=GREENMAIL_USER)

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -1,0 +1,120 @@
+"""Fixtures for Docker-based integration tests (Tier 2).
+
+GreenMail provides a real SMTP+IMAP server for full send→read roundtrip tests.
+Tests auto-skip if Docker is not available.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+
+import pytest
+
+from mcp_email_server.config import ConnectionSecurity, EmailServer
+from mcp_email_server.emails.classic import EmailClient
+
+# GreenMail accepts any credentials when auth is disabled
+GREENMAIL_USER = "testuser@localhost"
+GREENMAIL_PASSWORD = "testpass"  # noqa: S105
+
+GREENMAIL_SMTP_PORT = 3025
+GREENMAIL_IMAP_PORT = 3143
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip all docker tests if Docker is not available."""
+    if not shutil.which("docker"):
+        skip = pytest.mark.skip(reason="Docker not available")
+        for item in items:
+            item.add_marker(skip)
+
+
+@pytest.fixture(scope="session")
+def docker_compose_file():
+    """Point pytest-docker to our docker-compose.yml."""
+    import pathlib
+
+    return str(pathlib.Path(__file__).parent / "docker-compose.yml")
+
+
+@pytest.fixture(scope="session")
+def docker_setup():
+    """Override default 'up --build --wait' to avoid healthcheck requirement."""
+    return ["up --build -d"]
+
+
+def _greenmail_is_ready() -> bool:
+    """Check if GreenMail SMTP and IMAP services are actually ready.
+
+    A simple socket connection is insufficient — GreenMail may accept TCP
+    connections before the SMTP/IMAP handlers are initialized.
+    """
+    import smtplib
+
+    try:
+        # Test SMTP with a real EHLO handshake
+        with smtplib.SMTP("127.0.0.1", GREENMAIL_SMTP_PORT, timeout=3) as smtp:
+            smtp.ehlo()
+        # Test IMAP socket
+        with socket.create_connection(("127.0.0.1", GREENMAIL_IMAP_PORT), timeout=3):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="session")
+def greenmail(docker_services):
+    """Wait for GreenMail to be healthy and return connection details."""
+    docker_services.wait_until_responsive(
+        timeout=60.0,
+        pause=1.0,
+        check=_greenmail_is_ready,
+    )
+    return {
+        "smtp_host": "127.0.0.1",
+        "smtp_port": GREENMAIL_SMTP_PORT,
+        "imap_host": "127.0.0.1",
+        "imap_port": GREENMAIL_IMAP_PORT,
+        "user": GREENMAIL_USER,
+        "password": GREENMAIL_PASSWORD,
+    }
+
+
+@pytest.fixture()
+def greenmail_smtp_server(greenmail) -> EmailServer:
+    """EmailServer config for GreenMail SMTP."""
+    return EmailServer(
+        host=greenmail["smtp_host"],
+        port=greenmail["smtp_port"],
+        user_name=greenmail["user"],
+        password=greenmail["password"],
+        security=ConnectionSecurity.NONE,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def greenmail_imap_server(greenmail) -> EmailServer:
+    """EmailServer config for GreenMail IMAP."""
+    return EmailServer(
+        host=greenmail["imap_host"],
+        port=greenmail["imap_port"],
+        user_name=greenmail["user"],
+        password=greenmail["password"],
+        security=ConnectionSecurity.NONE,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def greenmail_smtp_client(greenmail_smtp_server) -> EmailClient:
+    """EmailClient wired to GreenMail SMTP."""
+    return EmailClient(greenmail_smtp_server, sender=GREENMAIL_USER)
+
+
+@pytest.fixture()
+def greenmail_imap_client(greenmail_imap_server) -> EmailClient:
+    """EmailClient wired to GreenMail IMAP."""
+    return EmailClient(greenmail_imap_server, sender=GREENMAIL_USER)

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -2,11 +2,11 @@ services:
   greenmail:
     image: greenmail/standalone:2.1.8
     ports:
-      - "3025:3025"   # SMTP
-      - "3143:3143"   # IMAP
-      - "3465:3465"   # SMTPS
-      - "3993:3993"   # IMAPS
-      - "8080:8080"   # REST API
+      - "3025:3025" # SMTP
+      - "3143:3143" # IMAP
+      - "3465:3465" # SMTPS
+      - "3993:3993" # IMAPS
+      - "8080:8080" # REST API
     environment:
       GREENMAIL_OPTS: >-
         -Dgreenmail.setup.test.all

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  greenmail:
+    image: greenmail/standalone:2.1.8
+    ports:
+      - "3025:3025"   # SMTP
+      - "3143:3143"   # IMAP
+      - "3465:3465"   # SMTPS
+      - "3993:3993"   # IMAPS
+      - "8080:8080"   # REST API
+    environment:
+      GREENMAIL_OPTS: >-
+        -Dgreenmail.setup.test.all
+        -Dgreenmail.hostname=0.0.0.0
+        -Dgreenmail.auth.disabled

--- a/tests/docker/test_roundtrip.py
+++ b/tests/docker/test_roundtrip.py
@@ -20,9 +20,7 @@ pytestmark = pytest.mark.docker
 
 async def _get_first_uid(imap_client) -> str:
     """Helper to get the first email UID from INBOX via metadata stream."""
-    async for email_data in imap_client.get_emails_metadata_stream(
-        mailbox="INBOX", page=1, page_size=1
-    ):
+    async for email_data in imap_client.get_emails_metadata_stream(mailbox="INBOX", page=1, page_size=1):
         return email_data.get("email_id") or email_data.get("uid")
     msg = "No emails found in INBOX"
     raise AssertionError(msg)

--- a/tests/docker/test_roundtrip.py
+++ b/tests/docker/test_roundtrip.py
@@ -1,0 +1,78 @@
+"""Docker integration tests: full SMTP→IMAP roundtrip via GreenMail.
+
+These tests send an email via SMTP, then read it back via IMAP to verify
+the complete email pipeline works end-to-end.
+
+Run: make test-docker
+Requires: Docker (auto-skips if not available)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from .conftest import GREENMAIL_USER
+
+pytestmark = pytest.mark.docker
+
+
+async def _get_first_uid(imap_client) -> str:
+    """Helper to get the first email UID from INBOX via metadata stream."""
+    async for email_data in imap_client.get_emails_metadata_stream(
+        mailbox="INBOX", page=1, page_size=1
+    ):
+        return email_data.get("email_id") or email_data.get("uid")
+    msg = "No emails found in INBOX"
+    raise AssertionError(msg)
+
+
+class TestSmtpImapRoundtrip:
+    """Send via SMTP → read via IMAP in GreenMail."""
+
+    async def test_send_and_count(self, greenmail_smtp_client, greenmail_imap_client):
+        """Send an email and verify the count increases."""
+        await greenmail_smtp_client.send_email(
+            recipients=[GREENMAIL_USER],
+            subject="Roundtrip Count Test",
+            body="Hello from Docker integration test!",
+        )
+
+        # GreenMail may need a moment to deliver
+        await asyncio.sleep(1)
+
+        count = await greenmail_imap_client.get_email_count(mailbox="INBOX")
+        assert count >= 1
+
+    async def test_send_and_read_body(self, greenmail_smtp_client, greenmail_imap_client):
+        """Send an email and verify the body content via IMAP."""
+        await greenmail_smtp_client.send_email(
+            recipients=[GREENMAIL_USER],
+            subject="Body Roundtrip",
+            body="Expected body content here.",
+        )
+
+        await asyncio.sleep(1)
+
+        uid = await _get_first_uid(greenmail_imap_client)
+        body_result = await greenmail_imap_client.get_email_body_by_id(uid, mailbox="INBOX")
+        assert body_result is not None
+        assert "body" in body_result
+
+    async def test_send_and_delete(self, greenmail_smtp_client, greenmail_imap_client):
+        """Send, read, delete, and verify the email is gone."""
+        await greenmail_smtp_client.send_email(
+            recipients=[GREENMAIL_USER],
+            subject="Delete Roundtrip",
+            body="This will be deleted.",
+        )
+
+        await asyncio.sleep(1)
+
+        count_before = await greenmail_imap_client.get_email_count(mailbox="INBOX")
+        assert count_before >= 1
+
+        uid = await _get_first_uid(greenmail_imap_client)
+        deleted, _failed = await greenmail_imap_client.delete_emails([uid], mailbox="INBOX")
+        assert uid in deleted

--- a/tests/docker/test_roundtrip.py
+++ b/tests/docker/test_roundtrip.py
@@ -1,7 +1,9 @@
-"""Docker integration tests: full SMTP→IMAP roundtrip via GreenMail.
+"""Docker integration tests: full SMTP/IMAP roundtrip via GreenMail.
 
-These tests send an email via SMTP, then read it back via IMAP to verify
-the complete email pipeline works end-to-end.
+Tests the complete email pipeline end-to-end across security modes:
+- NONE:     plaintext SMTP (3025) / IMAP (3143)
+- TLS:      SMTPS (3465) / IMAPS (3993)
+- STARTTLS: skipped (greenmail#135 — GreenMail does not support STARTTLS)
 
 Run: make test-docker
 Requires: Docker (auto-skips if not available)
@@ -12,6 +14,13 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+
+from mcp_email_server.emails.classic import (
+    test_imap_connection as check_imap_connection,
+)
+from mcp_email_server.emails.classic import (
+    test_smtp_connection as check_smtp_connection,
+)
 
 from .conftest import GREENMAIL_USER
 
@@ -26,8 +35,13 @@ async def _get_first_uid(imap_client) -> str:
     raise AssertionError(msg)
 
 
-class TestSmtpImapRoundtrip:
-    """Send via SMTP → read via IMAP in GreenMail."""
+# ---------------------------------------------------------------------------
+# Plaintext (NONE) roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtripPlaintext:
+    """Send via SMTP, read via IMAP in GreenMail (plaintext)."""
 
     async def test_send_and_count(self, greenmail_smtp_client, greenmail_imap_client):
         """Send an email and verify the count increases."""
@@ -36,8 +50,6 @@ class TestSmtpImapRoundtrip:
             subject="Roundtrip Count Test",
             body="Hello from Docker integration test!",
         )
-
-        # GreenMail may need a moment to deliver
         await asyncio.sleep(1)
 
         count = await greenmail_imap_client.get_email_count(mailbox="INBOX")
@@ -50,7 +62,6 @@ class TestSmtpImapRoundtrip:
             subject="Body Roundtrip",
             body="Expected body content here.",
         )
-
         await asyncio.sleep(1)
 
         uid = await _get_first_uid(greenmail_imap_client)
@@ -65,7 +76,6 @@ class TestSmtpImapRoundtrip:
             subject="Delete Roundtrip",
             body="This will be deleted.",
         )
-
         await asyncio.sleep(1)
 
         count_before = await greenmail_imap_client.get_email_count(mailbox="INBOX")
@@ -74,3 +84,87 @@ class TestSmtpImapRoundtrip:
         uid = await _get_first_uid(greenmail_imap_client)
         deleted, _failed = await greenmail_imap_client.delete_emails([uid], mailbox="INBOX")
         assert uid in deleted
+
+
+# ---------------------------------------------------------------------------
+# Implicit TLS (SMTPS/IMAPS) roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtripTLS:
+    """Send via SMTPS, read via IMAPS in GreenMail (Implicit TLS)."""
+
+    async def test_smtp_tls_connection(self, greenmail_smtps_server):
+        """Verify SMTPS connection succeeds."""
+        result = await check_smtp_connection(greenmail_smtps_server, timeout=10)
+        assert result.startswith("\u2705")
+        assert "tls" in result
+
+    async def test_imap_tls_connection(self, greenmail_imaps_server):
+        """Verify IMAPS connection succeeds."""
+        result = await check_imap_connection(greenmail_imaps_server, timeout=10)
+        assert result.startswith("\u2705")
+        assert "tls" in result
+
+    async def test_send_tls_read_tls(self, greenmail_smtps_client, greenmail_imaps_client):
+        """Full TLS roundtrip: send via SMTPS, read via IMAPS."""
+        await greenmail_smtps_client.send_email(
+            recipients=[GREENMAIL_USER],
+            subject="TLS Roundtrip",
+            body="Encrypted end-to-end!",
+        )
+        await asyncio.sleep(1)
+
+        count = await greenmail_imaps_client.get_email_count(mailbox="INBOX")
+        assert count >= 1
+
+        uid = await _get_first_uid(greenmail_imaps_client)
+        body_result = await greenmail_imaps_client.get_email_body_by_id(uid, mailbox="INBOX")
+        assert body_result is not None
+
+
+# ---------------------------------------------------------------------------
+# STARTTLS roundtrip
+# TODO(greenmail#135): GreenMail does not advertise STARTTLS on plaintext ports.
+# The SMTP EHLO response on port 3025 omits the STARTTLS extension, and the
+# IMAP CAPABILITY on port 3143 does not include STARTTLS.
+# STARTTLS is tested at Tier 1: SMTP via aiosmtpd, IMAP via unit tests.
+# See: https://github.com/greenmail-mail-test/greenmail/issues/135
+#
+# Uncomment when GreenMail adds STARTTLS support on plaintext ports.
+# ---------------------------------------------------------------------------
+#
+# class TestRoundtripSTARTTLS:
+#     """Send via SMTP+STARTTLS, read via IMAP+STARTTLS in GreenMail."""
+#
+#     async def test_smtp_starttls_connection(self, greenmail_smtp_starttls_server):
+#         """Verify SMTP STARTTLS connection succeeds."""
+#         result = await check_smtp_connection(greenmail_smtp_starttls_server, timeout=10)
+#         assert result.startswith("\u2705")
+#         assert "starttls" in result
+#
+#     async def test_imap_starttls_connection(self, greenmail_imap_starttls_server):
+#         """Verify IMAP STARTTLS connection succeeds."""
+#         result = await check_imap_connection(greenmail_imap_starttls_server, timeout=10)
+#         assert result.startswith("\u2705")
+#         assert "starttls" in result
+#
+#     async def test_send_starttls_read_starttls(
+#         self, greenmail_smtp_starttls_client, greenmail_imap_starttls_client
+#     ):
+#         """Full STARTTLS roundtrip: send + read with STARTTLS on both sides."""
+#         await greenmail_smtp_starttls_client.send_email(
+#             recipients=[GREENMAIL_USER],
+#             subject="STARTTLS Roundtrip",
+#             body="Upgraded to TLS on both sides!",
+#         )
+#         await asyncio.sleep(1)
+#
+#         count = await greenmail_imap_starttls_client.get_email_count(mailbox="INBOX")
+#         assert count >= 1
+#
+#         uid = await _get_first_uid(greenmail_imap_starttls_client)
+#         body_result = await greenmail_imap_starttls_client.get_email_body_by_id(
+#             uid, mailbox="INBOX"
+#         )
+#         assert body_result is not None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,168 @@
+"""Fixtures for integration tests against real protocol servers.
+
+Tier 1: Pure Python — no Docker required.
+- MockImapServer from aioimaplib (ships with runtime dependency)
+- pytest-localserver SMTP server (dev dependency group: integration)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import pytest
+from aioimaplib.imap_testing_server import Mail, MockImapServer
+from aiosmtpd.smtp import AuthResult
+from pytest_localserver.smtp import Handler, Server
+
+from mcp_email_server.config import ConnectionSecurity, EmailServer
+from mcp_email_server.emails.classic import EmailClient
+
+TEST_USER = "testuser@localhost"
+TEST_PASSWORD = "testpass"  # noqa: S105
+
+# MockImapServer stores mailbox names verbatim.  The production code
+# quotes mailbox names for RFC 3501 compatibility (_quote_mailbox wraps
+# them in double-quotes, e.g. '"INBOX"').  We must inject mail into
+# the *quoted* mailbox so it is visible to the production EmailClient.
+QUOTED_INBOX = '"INBOX"'
+
+
+def _accept_any(server, session, envelope, mechanism, auth_data):
+    """Authenticator that accepts any credentials (for testing)."""
+    return AuthResult(success=True)
+
+
+class AuthSmtpServer(Server):
+    """SMTP server that accepts AUTH LOGIN/PLAIN with any credentials."""
+
+    def __init__(self, host="localhost", port=0):
+        # Skip the parent __init__ and call Controller directly
+        from aiosmtpd.controller import Controller
+
+        Controller.__init__(
+            self,
+            Handler(),
+            hostname=host,
+            port=port,
+            authenticator=_accept_any,
+            auth_require_tls=False,
+        )
+
+
+def _free_port() -> int:
+    """Find a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture()
+async def imap_server_and_port():
+    """Start a MockImapServer on a random port for each test.
+
+    The server shares the test's event loop (required by aioimaplib).
+    Yields (server, port) so tests can inject mail and create clients.
+    """
+    port = _free_port()
+    loop = asyncio.get_running_loop()
+    server = MockImapServer(loop=loop)
+    real_server = await server.run_server(host="127.0.0.1", port=port)
+
+    yield server, port
+
+    server.reset()
+    real_server.close()
+    await real_server.wait_closed()
+
+
+@pytest.fixture()
+def imap_email_server(imap_server_and_port) -> EmailServer:
+    """Create an EmailServer config pointing at the MockImapServer."""
+    _, port = imap_server_and_port
+    return EmailServer(
+        host="127.0.0.1",
+        port=port,
+        user_name=TEST_USER,
+        password=TEST_PASSWORD,
+        security=ConnectionSecurity.NONE,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def imap_client(imap_email_server) -> EmailClient:
+    """Create an EmailClient wired to the MockImapServer."""
+    return EmailClient(imap_email_server, sender=TEST_USER)
+
+
+@pytest.fixture()
+def smtpserver(request):
+    """SMTP server fixture that supports AUTH (unlike pytest-localserver default)."""
+    server = AuthSmtpServer()
+    server.start()
+    request.addfinalizer(server.stop)
+    return server
+
+
+@pytest.fixture()
+def smtp_email_server(smtpserver) -> EmailServer:
+    """Create an EmailServer config pointing at our auth-enabled SMTP server."""
+    host, port = smtpserver.addr
+    return EmailServer(
+        host=host,
+        port=port,
+        user_name=TEST_USER,
+        password=TEST_PASSWORD,
+        security=ConnectionSecurity.NONE,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def smtp_client(smtp_email_server) -> EmailClient:
+    """Create an EmailClient wired to the pytest-localserver SMTP server."""
+    return EmailClient(smtp_email_server, sender=TEST_USER)
+
+
+def make_test_mail(
+    to: str = TEST_USER,
+    subject: str = "Test Subject",
+    body: str = "Hello, World!",
+    mail_from: str = "sender@localhost",
+    **kwargs,
+) -> Mail:
+    """Create a Mail object for injection into MockImapServer."""
+    return Mail.create(
+        to=[to],
+        mail_from=mail_from,
+        subject=subject,
+        content=body,
+        **kwargs,
+    )
+
+
+def make_multipart_mail(
+    to: str = TEST_USER,
+    subject: str = "Test with Attachment",
+    body: str = "See attached.",
+    mail_from: str = "sender@localhost",
+    attachment_name: str = "test.txt",
+    attachment_content: bytes = b"attachment content",
+) -> Mail:
+    """Create a multipart Mail with an attachment for MockImapServer injection."""
+    msg = MIMEMultipart()
+    msg["To"] = to
+    msg["From"] = mail_from
+    msg["Subject"] = subject
+    msg.attach(MIMEText(body, "plain", "utf-8"))
+
+    part = MIMEApplication(attachment_content, Name=attachment_name)
+    part["Content-Disposition"] = f'attachment; filename="{attachment_name}"'
+    msg.attach(part)
+
+    return Mail(msg)
+

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -165,4 +165,3 @@ def make_multipart_mail(
     msg.attach(part)
 
     return Mail(msg)
-

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,12 +3,21 @@
 Tier 1: Pure Python — no Docker required.
 - MockImapServer from aioimaplib (ships with runtime dependency)
 - pytest-localserver SMTP server (dev dependency group: integration)
+
+Provides fixtures for all three ConnectionSecurity modes:
+- NONE:     plaintext IMAP + SMTP (default fixtures)
+- TLS:      Implicit TLS IMAP + SMTP via self-signed certs
+- STARTTLS: tested at Docker tier (MockImapServer lacks STARTTLS support)
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import ipaddress
 import socket
+import ssl
+import tempfile
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -20,6 +29,34 @@ from pytest_localserver.smtp import Handler, Server
 
 from mcp_email_server.config import ConnectionSecurity, EmailServer
 from mcp_email_server.emails.classic import EmailClient
+
+# ---------------------------------------------------------------------------
+# Workaround: aioimaplib#128 — dangling asyncio tasks after IMAP connections
+# aioimaplib's _client_task does not support asyncio cancellation and can
+# linger after imap.logout(), preventing clean event-loop shutdown.
+# This autouse fixture cancels all dangling tasks after each test.
+# See: https://github.com/iroco-co/aioimaplib/issues/128
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_dangling_imap_tasks():
+    """Cancel lingering aioimaplib tasks after each test to prevent hangs.
+
+    Workaround for https://github.com/iroco-co/aioimaplib/issues/128
+    aioimaplib's _client_task spawns asyncio tasks (create_connection, etc.)
+    that do not support cancellation and linger after imap.logout().
+    """
+    tasks_before = set(asyncio.all_tasks())
+    yield
+    await asyncio.sleep(0.05)
+    for task in asyncio.all_tasks() - tasks_before:
+        if task.done() or task == asyncio.current_task():
+            continue
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
+
 
 TEST_USER = "testuser@localhost"
 TEST_PASSWORD = "testpass"  # noqa: S105
@@ -39,8 +76,28 @@ def _accept_any(server, session, envelope, mechanism, auth_data):
 class AuthSmtpServer(Server):
     """SMTP server that accepts AUTH LOGIN/PLAIN with any credentials."""
 
-    def __init__(self, host="localhost", port=0):
-        # Skip the parent __init__ and call Controller directly
+    def __init__(self, host="localhost", port=0, ssl_context=None):
+        from aiosmtpd.controller import Controller
+
+        kwargs = {
+            "authenticator": _accept_any,
+            "auth_require_tls": False,
+        }
+        if ssl_context is not None:
+            kwargs["tls_context"] = ssl_context
+        Controller.__init__(
+            self,
+            Handler(),
+            hostname=host,
+            port=port,
+            **kwargs,
+        )
+
+
+class AuthSmtpServerTLS(Server):
+    """SMTP server that speaks Implicit TLS (wraps socket in TLS immediately)."""
+
+    def __init__(self, host="localhost", port=0, ssl_context=None):
         from aiosmtpd.controller import Controller
 
         Controller.__init__(
@@ -50,6 +107,7 @@ class AuthSmtpServer(Server):
             port=port,
             authenticator=_accept_any,
             auth_require_tls=False,
+            ssl_context=ssl_context,
         )
 
 
@@ -58,6 +116,85 @@ def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
+
+
+def _generate_self_signed_cert():
+    """Generate a self-signed certificate and key for testing TLS.
+
+    Returns (certfile_path, keyfile_path) as temporary files.
+    Uses the cryptography library which ships with most Python environments.
+    """
+    import datetime
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+
+    cert = (
+        x509
+        .CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.DNSName("localhost"),
+                x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
+            ]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    certfile = tempfile.NamedTemporaryFile(suffix=".pem", delete=False)  # noqa: SIM115
+    certfile.write(cert.public_bytes(serialization.Encoding.PEM))
+    certfile.close()
+
+    keyfile = tempfile.NamedTemporaryFile(suffix=".pem", delete=False)  # noqa: SIM115
+    keyfile.write(
+        key.private_bytes(
+            serialization.Encoding.PEM, serialization.PrivateFormat.TraditionalOpenSSL, serialization.NoEncryption()
+        )
+    )
+    keyfile.close()
+
+    return certfile.name, keyfile.name
+
+
+@pytest.fixture(scope="session")
+def self_signed_cert():
+    """Session-scoped self-signed TLS certificate for testing.
+
+    Yields (certfile, keyfile, server_ssl_context, client_ssl_context).
+    """
+    import os
+
+    certfile, keyfile = _generate_self_signed_cert()
+
+    # Server-side context
+    server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(certfile, keyfile)
+
+    # Client-side context (trusts the self-signed cert)
+    client_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    client_ctx.load_verify_locations(certfile)
+
+    yield certfile, keyfile, server_ctx, client_ctx
+
+    os.unlink(certfile)
+    os.unlink(keyfile)
+
+
+# ---------------------------------------------------------------------------
+# Plaintext (NONE) fixtures — default
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -76,7 +213,9 @@ async def imap_server_and_port():
 
     server.reset()
     real_server.close()
-    await real_server.wait_closed()
+    # wait_closed() can hang if aioimaplib left dangling connections (aioimaplib#128)
+    with contextlib.suppress(TimeoutError, asyncio.TimeoutError):
+        await asyncio.wait_for(real_server.wait_closed(), timeout=1.0)
 
 
 @pytest.fixture()
@@ -126,6 +265,119 @@ def smtp_email_server(smtpserver) -> EmailServer:
 def smtp_client(smtp_email_server) -> EmailClient:
     """Create an EmailClient wired to the pytest-localserver SMTP server."""
     return EmailClient(smtp_email_server, sender=TEST_USER)
+
+
+# ---------------------------------------------------------------------------
+# Implicit TLS fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def imap_tls_server_and_port(self_signed_cert):
+    """Start a MockImapServer with Implicit TLS on a random port."""
+    _, _, server_ctx, _ = self_signed_cert
+    port = _free_port()
+    loop = asyncio.get_running_loop()
+    server = MockImapServer(loop=loop)
+    real_server = await server.run_server(host="127.0.0.1", port=port, ssl_context=server_ctx)
+
+    yield server, port
+
+    server.reset()
+    real_server.close()
+    # wait_closed() can hang if aioimaplib left dangling connections (aioimaplib#128)
+    with contextlib.suppress(TimeoutError, asyncio.TimeoutError):
+        await asyncio.wait_for(real_server.wait_closed(), timeout=1.0)
+
+
+@pytest.fixture()
+def imap_tls_email_server(imap_tls_server_and_port) -> EmailServer:
+    """EmailServer config for Implicit TLS IMAP (verify_ssl=False for self-signed)."""
+    _, port = imap_tls_server_and_port
+    return EmailServer(
+        host="127.0.0.1",
+        port=port,
+        user_name=TEST_USER,
+        password=TEST_PASSWORD,
+        security=ConnectionSecurity.TLS,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def imap_tls_client(imap_tls_email_server) -> EmailClient:
+    """EmailClient wired to MockImapServer over Implicit TLS."""
+    return EmailClient(imap_tls_email_server, sender=TEST_USER)
+
+
+@pytest.fixture()
+def smtpserver_tls(request, self_signed_cert):
+    """SMTP server with Implicit TLS (wraps socket in TLS on connect)."""
+    _, _, server_ctx, _ = self_signed_cert
+    server = AuthSmtpServerTLS(ssl_context=server_ctx)
+    server.start()
+    request.addfinalizer(server.stop)
+    return server
+
+
+@pytest.fixture()
+def smtp_tls_email_server(smtpserver_tls) -> EmailServer:
+    """EmailServer config for Implicit TLS SMTP."""
+    host, port = smtpserver_tls.addr
+    return EmailServer(
+        host=host,
+        port=port,
+        user_name=TEST_USER,
+        password=TEST_PASSWORD,
+        security=ConnectionSecurity.TLS,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def smtp_tls_client(smtp_tls_email_server) -> EmailClient:
+    """EmailClient wired to SMTP over Implicit TLS."""
+    return EmailClient(smtp_tls_email_server, sender=TEST_USER)
+
+
+# ---------------------------------------------------------------------------
+# STARTTLS SMTP fixture (MockImapServer lacks STARTTLS protocol support)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def smtpserver_starttls(request, self_signed_cert):
+    """SMTP server that supports STARTTLS upgrade."""
+    _, _, server_ctx, _ = self_signed_cert
+    server = AuthSmtpServer(ssl_context=server_ctx)
+    server.start()
+    request.addfinalizer(server.stop)
+    return server
+
+
+@pytest.fixture()
+def smtp_starttls_email_server(smtpserver_starttls) -> EmailServer:
+    """EmailServer config for SMTP STARTTLS."""
+    host, port = smtpserver_starttls.addr
+    return EmailServer(
+        host=host,
+        port=port,
+        user_name=TEST_USER,
+        password=TEST_PASSWORD,
+        security=ConnectionSecurity.STARTTLS,
+        verify_ssl=False,
+    )
+
+
+@pytest.fixture()
+def smtp_starttls_client(smtp_starttls_email_server) -> EmailClient:
+    """EmailClient wired to SMTP with STARTTLS upgrade."""
+    return EmailClient(smtp_starttls_email_server, sender=TEST_USER)
+
+
+# ---------------------------------------------------------------------------
+# Mail helpers
+# ---------------------------------------------------------------------------
 
 
 def make_test_mail(

--- a/tests/integration/test_imap_live.py
+++ b/tests/integration/test_imap_live.py
@@ -1,0 +1,136 @@
+"""Integration tests for IMAP operations against MockImapServer.
+
+These tests exercise the real EmailClient methods against a live IMAP server
+running in-process. No mocks — every byte goes over a TCP socket.
+
+Note: MockImapServer does NOT support INTERNALDATE or BODY.PEEK[HEADER],
+so get_emails_metadata_stream() cannot be tested here. Use GreenMail
+Docker tests (Tier 2) for full metadata/roundtrip coverage.
+
+Run: make test-integration
+"""
+
+from __future__ import annotations
+
+from email.mime.text import MIMEText
+
+import pytest
+
+from mcp_email_server.config import ConnectionSecurity, EmailServer
+from mcp_email_server.emails.classic import test_imap_connection as check_imap_connection
+
+from .conftest import QUOTED_INBOX, TEST_USER, make_multipart_mail, make_test_mail
+
+pytestmark = pytest.mark.integration
+
+
+class TestImapConnectionLive:
+    """Test IMAP connection against a real server."""
+
+    async def test_connection_success(self, imap_server_and_port, imap_email_server):
+        result = await check_imap_connection(imap_email_server, timeout=5)
+        assert result.startswith("✅")
+        assert "successful" in result
+
+    async def test_connection_wrong_port(self):
+        server = EmailServer(
+            host="127.0.0.1",
+            port=1,
+            user_name="x",
+            password="x",
+            security=ConnectionSecurity.NONE,
+            verify_ssl=False,
+        )
+        result = await check_imap_connection(server, timeout=2)
+        assert result.startswith("❌")
+
+
+class TestGetEmailCount:
+    """Test get_email_count against MockImapServer."""
+
+    async def test_empty_inbox(self, imap_server_and_port, imap_client):
+        count = await imap_client.get_email_count(mailbox="INBOX")
+        assert count == 0
+
+    async def test_with_injected_emails(self, imap_server_and_port, imap_client):
+        server, _ = imap_server_and_port
+        server.receive(make_test_mail(subject="Email 1"), imap_user=TEST_USER, mailbox=QUOTED_INBOX)
+        server.receive(make_test_mail(subject="Email 2"), imap_user=TEST_USER, mailbox=QUOTED_INBOX)
+        server.receive(make_test_mail(subject="Email 3"), imap_user=TEST_USER, mailbox=QUOTED_INBOX)
+
+        count = await imap_client.get_email_count(mailbox="INBOX")
+        assert count == 3
+
+
+class TestGetEmailBody:
+    """Test get_email_body_by_id against MockImapServer."""
+
+    async def test_body_extraction(self, imap_server_and_port, imap_client):
+        server, _ = imap_server_and_port
+        server.receive(
+            make_test_mail(subject="Body Test", body="This is the body content."),
+            imap_user=TEST_USER,
+            mailbox=QUOTED_INBOX,
+        )
+
+        body_result = await imap_client.get_email_body_by_id("1", mailbox="INBOX")
+        assert body_result is not None
+        assert "body" in body_result
+
+
+class TestDownloadAttachment:
+    """Test download_attachment against MockImapServer."""
+
+    async def test_attachment_download(self, imap_server_and_port, imap_client, tmp_path):
+        server, _ = imap_server_and_port
+        attachment_content = b"Hello from attachment!"
+        server.receive(
+            make_multipart_mail(
+                subject="Attachment Test",
+                attachment_name="notes.txt",
+                attachment_content=attachment_content,
+            ),
+            imap_user=TEST_USER,
+            mailbox=QUOTED_INBOX,
+        )
+
+        save_path = str(tmp_path / "notes.txt")
+        download = await imap_client.download_attachment("1", "notes.txt", save_path, mailbox="INBOX")
+
+        assert download["attachment_name"] == "notes.txt"
+        assert download["size"] == len(attachment_content)
+        assert (tmp_path / "notes.txt").read_bytes() == attachment_content
+
+
+class TestDeleteEmails:
+    """Test delete_emails against MockImapServer."""
+
+    async def test_delete_and_verify_gone(self, imap_server_and_port, imap_client):
+        server, _ = imap_server_and_port
+        server.receive(make_test_mail(subject="To Delete"), imap_user=TEST_USER, mailbox=QUOTED_INBOX)
+
+        # Verify exists
+        count_before = await imap_client.get_email_count(mailbox="INBOX")
+        assert count_before == 1
+
+        # Delete UID 1
+        deleted, failed = await imap_client.delete_emails(["1"], mailbox="INBOX")
+        assert "1" in deleted
+        assert len(failed) == 0
+
+        # Verify gone
+        count_after = await imap_client.get_email_count(mailbox="INBOX")
+        assert count_after == 0
+
+
+class TestAppendToSent:
+    """Test append_to_sent against MockImapServer."""
+
+    async def test_append_message(self, imap_server_and_port, imap_client, imap_email_server):
+        msg = MIMEText("Sent message body", "plain", "utf-8")
+        msg["Subject"] = "Sent Test"
+        msg["From"] = TEST_USER
+        msg["To"] = "recipient@localhost"
+
+        result = await imap_client.append_to_sent(msg, imap_email_server)
+        assert result is True

--- a/tests/integration/test_imap_security.py
+++ b/tests/integration/test_imap_security.py
@@ -1,0 +1,141 @@
+"""Integration tests for IMAP with different security settings.
+
+Tests exercise EmailClient against MockImapServer in multiple security modes:
+- ConnectionSecurity.NONE  (plaintext — covered in test_imap_live.py)
+- ConnectionSecurity.TLS   (Implicit TLS via self-signed cert)
+- Connection test diagnostics with wrong security settings
+
+MockImapServer does NOT support STARTTLS protocol, so STARTTLS IMAP is
+tested only at the Docker tier (GreenMail).
+
+Run: make test-integration
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_email_server.config import ConnectionSecurity, EmailServer
+from mcp_email_server.emails.classic import test_imap_connection as check_imap_connection
+
+from .conftest import QUOTED_INBOX, TEST_PASSWORD, TEST_USER, make_test_mail
+
+pytestmark = pytest.mark.integration
+
+
+class TestImapImplicitTLS:
+    """IMAP operations over Implicit TLS (ConnectionSecurity.TLS)."""
+
+    async def test_connection_success(self, imap_tls_server_and_port, imap_tls_email_server):
+        """Verify TLS connection + login succeeds with self-signed cert."""
+        result = await check_imap_connection(imap_tls_email_server, timeout=5)
+        assert result.startswith("✅")
+        assert "tls" in result
+
+    async def test_email_count(self, imap_tls_server_and_port, imap_tls_client):
+        """Verify email count works over TLS."""
+        server, _ = imap_tls_server_and_port
+        server.receive(make_test_mail(subject="TLS Email"), imap_user=TEST_USER, mailbox=QUOTED_INBOX)
+
+        count = await imap_tls_client.get_email_count(mailbox="INBOX")
+        assert count == 1
+
+    async def test_email_body(self, imap_tls_server_and_port, imap_tls_client):
+        """Verify body extraction works over TLS."""
+        server, _ = imap_tls_server_and_port
+        server.receive(
+            make_test_mail(subject="TLS Body", body="Encrypted body content."),
+            imap_user=TEST_USER,
+            mailbox=QUOTED_INBOX,
+        )
+
+        result = await imap_tls_client.get_email_body_by_id("1", mailbox="INBOX")
+        assert result is not None
+        assert "body" in result
+
+    async def test_delete_over_tls(self, imap_tls_server_and_port, imap_tls_client):
+        """Verify delete works over TLS."""
+        server, _ = imap_tls_server_and_port
+        server.receive(make_test_mail(subject="TLS Delete"), imap_user=TEST_USER, mailbox=QUOTED_INBOX)
+
+        deleted, failed = await imap_tls_client.delete_emails(["1"], mailbox="INBOX")
+        assert "1" in deleted
+        assert len(failed) == 0
+
+
+class TestImapSecurityMismatch:
+    """Test that wrong security settings produce clear error messages."""
+
+    async def test_tls_on_plaintext_server(self, imap_server_and_port):
+        """TLS client against plaintext server should fail with clear error."""
+        _, port = imap_server_and_port
+        server = EmailServer(
+            host="127.0.0.1",
+            port=port,
+            user_name=TEST_USER,
+            password=TEST_PASSWORD,
+            security=ConnectionSecurity.TLS,
+            verify_ssl=False,
+        )
+        result = await check_imap_connection(server, timeout=3)
+        assert result.startswith("❌")
+
+    async def test_starttls_on_plaintext_server(self, imap_server_and_port):
+        """STARTTLS against a server without STARTTLS capability should fail clearly."""
+        _, port = imap_server_and_port
+        server = EmailServer(
+            host="127.0.0.1",
+            port=port,
+            user_name=TEST_USER,
+            password=TEST_PASSWORD,
+            security=ConnectionSecurity.STARTTLS,
+            verify_ssl=False,
+        )
+        result = await check_imap_connection(server, timeout=3)
+        assert result.startswith("❌")
+        assert "STARTTLS" in result
+
+
+# ---------------------------------------------------------------------------
+# Blocked IMAP mismatch tests
+# TODO(aioimaplib#128): aioimaplib's internal tasks do not support asyncio
+# cancellation. Connecting with the wrong security mode (e.g. plaintext client
+# to a TLS server, or verify_ssl=True with a self-signed cert) causes
+# test_imap_connection() to hang indefinitely — the internal _client_task
+# holds transport references that prevent cleanup.
+# See: https://github.com/iroco-co/aioimaplib/issues/128
+#
+# Uncomment when aioimaplib#128 is resolved upstream.
+# ---------------------------------------------------------------------------
+#
+# class TestImapSecurityMismatchBlocked:
+#     """Tests blocked by aioimaplib#128 (connection hangs on security mismatch)."""
+#
+#     async def test_plaintext_on_tls_server(self, imap_tls_server_and_port):
+#         """Plaintext client against TLS server should time out with clear error."""
+#         _, port = imap_tls_server_and_port
+#         server = EmailServer(
+#             host="127.0.0.1",
+#             port=port,
+#             user_name=TEST_USER,
+#             password=TEST_PASSWORD,
+#             security=ConnectionSecurity.NONE,
+#             verify_ssl=False,
+#         )
+#         result = await check_imap_connection(server, timeout=3)
+#         assert result.startswith("❌")
+#
+#     async def test_verify_ssl_true_rejects_self_signed(self, imap_tls_server_and_port):
+#         """verify_ssl=True should reject our self-signed certificate."""
+#         _, port = imap_tls_server_and_port
+#         server = EmailServer(
+#             host="127.0.0.1",
+#             port=port,
+#             user_name=TEST_USER,
+#             password=TEST_PASSWORD,
+#             security=ConnectionSecurity.TLS,
+#             verify_ssl=True,
+#         )
+#         result = await check_imap_connection(server, timeout=3)
+#         assert result.startswith("❌")
+#         assert "SSL" in result or "certificate" in result.lower() or "timed out" in result.lower()

--- a/tests/integration/test_smtp_live.py
+++ b/tests/integration/test_smtp_live.py
@@ -1,0 +1,152 @@
+"""Integration tests for SMTP operations against pytest-localserver.
+
+These tests exercise the real EmailClient.send_email() method against a live
+SMTP server. Sent messages are captured in smtpserver.outbox for inspection.
+
+Run: make test-integration
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_email_server.emails.classic import test_smtp_connection as check_smtp_connection
+
+from .conftest import TEST_USER
+
+pytestmark = pytest.mark.integration
+
+
+class TestSmtpConnectionLive:
+    """Test SMTP connection against a real server."""
+
+    async def test_connection_success(self, smtp_email_server):
+        result = await check_smtp_connection(smtp_email_server, timeout=5)
+        assert result.startswith("✅")
+        assert "successful" in result
+
+
+class TestSendEmail:
+    """Test send_email against pytest-localserver SMTP."""
+
+    async def test_send_basic_email(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["recipient@localhost"],
+            subject="Basic Test",
+            body="Hello from integration test!",
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        assert msg["Subject"] == "Basic Test"
+        assert msg["To"] == "recipient@localhost"
+        assert msg["From"] == TEST_USER
+
+    async def test_send_email_with_cc(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["to@localhost"],
+            subject="CC Test",
+            body="With CC",
+            cc=["cc1@localhost", "cc2@localhost"],
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        assert msg["Cc"] == "cc1@localhost, cc2@localhost"
+
+    async def test_send_email_with_bcc(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["to@localhost"],
+            subject="BCC Test",
+            body="With BCC",
+            bcc=["secret@localhost"],
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        # BCC should NOT appear in headers
+        assert msg.get("Bcc") is None
+
+    async def test_send_html_email(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["to@localhost"],
+            subject="HTML Test",
+            body="<h1>Hello</h1>",
+            html=True,
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        assert msg.get_content_type() == "text/html"
+
+    async def test_send_email_with_attachment(self, smtp_client, smtpserver, tmp_path):
+        # Create a temporary attachment file
+        attachment = tmp_path / "test.txt"
+        attachment.write_text("attachment content")
+
+        await smtp_client.send_email(
+            recipients=["to@localhost"],
+            subject="Attachment Test",
+            body="See attached",
+            attachments=[str(attachment)],
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        assert msg.is_multipart()
+
+        # Find the attachment part
+        parts = list(msg.walk())
+        attachment_parts = [
+            p for p in parts if p.get("Content-Disposition") and "attachment" in p.get("Content-Disposition", "")
+        ]
+        assert len(attachment_parts) == 1
+        assert "test.txt" in attachment_parts[0].get_filename()
+
+    async def test_send_reply_email(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["to@localhost"],
+            subject="Re: Original Subject",
+            body="My reply",
+            in_reply_to="<original-id@localhost>",
+            references="<original-id@localhost>",
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        assert msg["In-Reply-To"] == "<original-id@localhost>"
+        assert msg["References"] == "<original-id@localhost>"
+
+    async def test_send_sets_message_id_and_date(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["to@localhost"],
+            subject="Headers Test",
+            body="Check headers",
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        assert msg["Message-Id"] is not None
+        assert msg["Date"] is not None
+
+    async def test_send_unicode_subject(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["to@localhost"],
+            subject="日本語テスト",
+            body="Unicode subject test",
+        )
+
+        assert len(smtpserver.outbox) == 1
+
+    async def test_send_multiple_recipients(self, smtp_client, smtpserver):
+        await smtp_client.send_email(
+            recipients=["a@localhost", "b@localhost", "c@localhost"],
+            subject="Multi-recipient",
+            body="To multiple people",
+        )
+
+        assert len(smtpserver.outbox) == 1
+        msg = smtpserver.outbox[0]
+        assert "a@localhost" in msg["To"]
+        assert "b@localhost" in msg["To"]
+        assert "c@localhost" in msg["To"]

--- a/tests/integration/test_smtp_security.py
+++ b/tests/integration/test_smtp_security.py
@@ -1,0 +1,154 @@
+"""Integration tests for SMTP with different security settings.
+
+Tests exercise EmailClient.send_email() in multiple security modes:
+- ConnectionSecurity.NONE     (plaintext — covered in test_smtp_live.py)
+- ConnectionSecurity.TLS      (Implicit TLS via self-signed cert)
+- ConnectionSecurity.STARTTLS (upgrade to TLS via STARTTLS command)
+- Connection test diagnostics with wrong security settings
+
+Run: make test-integration
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_email_server.config import ConnectionSecurity, EmailServer
+from mcp_email_server.emails.classic import test_smtp_connection as check_smtp_connection
+
+from .conftest import TEST_PASSWORD, TEST_USER
+
+pytestmark = pytest.mark.integration
+
+
+class TestSmtpImplicitTLS:
+    """SMTP operations over Implicit TLS (ConnectionSecurity.TLS)."""
+
+    async def test_connection_success(self, smtp_tls_email_server):
+        """Verify TLS connection + login succeeds."""
+        result = await check_smtp_connection(smtp_tls_email_server, timeout=5)
+        assert result.startswith("✅")
+        assert "tls" in result
+
+    async def test_send_basic_email(self, smtp_tls_client, smtpserver_tls):
+        """Verify sending works over Implicit TLS."""
+        await smtp_tls_client.send_email(
+            recipients=["to@localhost"],
+            subject="TLS Send Test",
+            body="Sent over Implicit TLS!",
+        )
+
+        assert len(smtpserver_tls.outbox) == 1
+        msg = smtpserver_tls.outbox[0]
+        assert msg["Subject"] == "TLS Send Test"
+
+    async def test_send_html_email(self, smtp_tls_client, smtpserver_tls):
+        """Verify HTML emails work over TLS."""
+        await smtp_tls_client.send_email(
+            recipients=["to@localhost"],
+            subject="TLS HTML",
+            body="<h1>TLS</h1>",
+            html=True,
+        )
+
+        assert len(smtpserver_tls.outbox) == 1
+        assert smtpserver_tls.outbox[0].get_content_type() == "text/html"
+
+    async def test_send_with_attachment(self, smtp_tls_client, smtpserver_tls, tmp_path):
+        """Verify attachments work over TLS."""
+        attachment = tmp_path / "secure.txt"
+        attachment.write_text("secure attachment")
+
+        await smtp_tls_client.send_email(
+            recipients=["to@localhost"],
+            subject="TLS Attachment",
+            body="See attached",
+            attachments=[str(attachment)],
+        )
+
+        assert len(smtpserver_tls.outbox) == 1
+        assert smtpserver_tls.outbox[0].is_multipart()
+
+
+class TestSmtpStartTLS:
+    """SMTP operations with STARTTLS upgrade."""
+
+    async def test_connection_success(self, smtp_starttls_email_server):
+        """Verify STARTTLS connection + login succeeds."""
+        result = await check_smtp_connection(smtp_starttls_email_server, timeout=5)
+        assert result.startswith("✅")
+        assert "starttls" in result
+
+    async def test_send_basic_email(self, smtp_starttls_client, smtpserver_starttls):
+        """Verify sending works with STARTTLS upgrade."""
+        await smtp_starttls_client.send_email(
+            recipients=["to@localhost"],
+            subject="STARTTLS Send Test",
+            body="Sent with STARTTLS upgrade!",
+        )
+
+        assert len(smtpserver_starttls.outbox) == 1
+        msg = smtpserver_starttls.outbox[0]
+        assert msg["Subject"] == "STARTTLS Send Test"
+
+    async def test_send_with_cc_bcc(self, smtp_starttls_client, smtpserver_starttls):
+        """Verify CC/BCC work with STARTTLS."""
+        await smtp_starttls_client.send_email(
+            recipients=["to@localhost"],
+            subject="STARTTLS CC/BCC",
+            body="CC and BCC over STARTTLS",
+            cc=["cc@localhost"],
+            bcc=["bcc@localhost"],
+        )
+
+        assert len(smtpserver_starttls.outbox) == 1
+        msg = smtpserver_starttls.outbox[0]
+        assert msg["Cc"] == "cc@localhost"
+        assert msg.get("Bcc") is None
+
+
+class TestSmtpSecurityMismatch:
+    """Test that wrong security settings produce clear error messages."""
+
+    async def test_tls_on_plaintext_server(self, smtpserver):
+        """TLS client against plaintext SMTP server should fail clearly."""
+        host, port = smtpserver.addr
+        server = EmailServer(
+            host=host,
+            port=port,
+            user_name=TEST_USER,
+            password=TEST_PASSWORD,
+            security=ConnectionSecurity.TLS,
+            verify_ssl=False,
+        )
+        result = await check_smtp_connection(server, timeout=3)
+        assert result.startswith("❌")
+
+    async def test_plaintext_on_tls_server(self, smtpserver_tls):
+        """Plaintext client against TLS SMTP server should fail."""
+        host, port = smtpserver_tls.addr
+        server = EmailServer(
+            host=host,
+            port=port,
+            user_name=TEST_USER,
+            password=TEST_PASSWORD,
+            security=ConnectionSecurity.NONE,
+            verify_ssl=False,
+        )
+        result = await check_smtp_connection(server, timeout=3)
+        assert result.startswith("❌")
+
+    async def test_verify_ssl_true_rejects_self_signed(self, smtpserver_tls):
+        """verify_ssl=True should reject our self-signed certificate."""
+        host, port = smtpserver_tls.addr
+        server = EmailServer(
+            host=host,
+            port=port,
+            user_name=TEST_USER,
+            password=TEST_PASSWORD,
+            security=ConnectionSecurity.TLS,
+            verify_ssl=True,
+        )
+        result = await check_smtp_connection(server, timeout=3)
+        assert result.startswith("❌")
+        assert "SSL" in result or "certificate" in result.lower()

--- a/tests/test_email_attachments.py
+++ b/tests/test_email_attachments.py
@@ -232,7 +232,7 @@ class TestDownloadAttachmentMailboxParam:
 
         # Mock _fetch_email_with_formats to return None (will raise ValueError)
         with patch.object(email_client, "_fetch_email_with_formats", return_value=None):
-            with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_connect_imap", return_value=mock_imap):
                 with pytest.raises(ValueError):
                     await email_client.download_attachment(
                         email_id="123",
@@ -246,20 +246,16 @@ class TestDownloadAttachmentMailboxParam:
     @pytest.mark.asyncio
     async def test_download_attachment_custom_mailbox(self, email_client, tmp_path):
         """Test download_attachment with custom mailbox parameter."""
-        import asyncio
 
         save_path = str(tmp_path / "attachment.pdf")
 
         mock_imap = AsyncMock()
-        mock_imap._client_task = asyncio.Future()
-        mock_imap._client_task.set_result(None)
-        mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
         mock_imap.select = AsyncMock(return_value=("OK", [b"1"]))
         mock_imap.logout = AsyncMock()
 
         with patch.object(email_client, "_fetch_email_with_formats", return_value=None):
-            with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_connect_imap", return_value=mock_imap):
                 with pytest.raises(ValueError):
                     await email_client.download_attachment(
                         email_id="123",
@@ -274,20 +270,16 @@ class TestDownloadAttachmentMailboxParam:
     @pytest.mark.asyncio
     async def test_download_attachment_special_folder(self, email_client, tmp_path):
         """Test download_attachment with special folder like [Gmail]/Sent Mail."""
-        import asyncio
 
         save_path = str(tmp_path / "attachment.pdf")
 
         mock_imap = AsyncMock()
-        mock_imap._client_task = asyncio.Future()
-        mock_imap._client_task.set_result(None)
-        mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
         mock_imap.select = AsyncMock(return_value=("OK", [b"1"]))
         mock_imap.logout = AsyncMock()
 
         with patch.object(email_client, "_fetch_email_with_formats", return_value=None):
-            with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_connect_imap", return_value=mock_imap):
                 with pytest.raises(ValueError):
                     await email_client.download_attachment(
                         email_id="123",

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -235,7 +235,7 @@ class TestEmailClient:
             },
         }
 
-        with patch.object(email_client, "imap_class", return_value=mock_imap):
+        with patch.object(email_client, "_connect_imap", return_value=mock_imap):
             with patch.object(email_client, "_batch_fetch_dates", return_value=mock_dates) as mock_fetch_dates:
                 with patch.object(
                     email_client, "_batch_fetch_headers", return_value=mock_metadata
@@ -273,7 +273,7 @@ class TestEmailClient:
         mock_imap.logout = AsyncMock()
 
         # Mock IMAP class
-        with patch.object(email_client, "imap_class", return_value=mock_imap):
+        with patch.object(email_client, "_connect_imap", return_value=mock_imap):
             count = await email_client.get_email_count()
 
             assert count == 5

--- a/tests/test_imap_starttls.py
+++ b/tests/test_imap_starttls.py
@@ -1,0 +1,452 @@
+"""Tests for IMAP STARTTLS support and ConnectionSecurity enum."""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_email_server.config import ConnectionSecurity, EmailServer, EmailSettings
+
+
+class TestConnectionSecurity:
+    """Tests for the ConnectionSecurity enum and EmailServer model."""
+
+    def test_default_security_is_tls(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993)
+        assert server.security == ConnectionSecurity.TLS
+
+    def test_explicit_security_tls(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993, security="tls")
+        assert server.security == ConnectionSecurity.TLS
+
+    def test_explicit_security_starttls(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, security="starttls")
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_explicit_security_none(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, security="none")
+        assert server.security == ConnectionSecurity.NONE
+
+    def test_legacy_use_ssl_true(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993, use_ssl=True)
+        assert server.security == ConnectionSecurity.TLS
+
+    def test_legacy_use_ssl_false_start_ssl_true(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, use_ssl=False, start_ssl=True)
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_legacy_use_ssl_false_start_ssl_false(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, use_ssl=False, start_ssl=False)
+        assert server.security == ConnectionSecurity.NONE
+
+    def test_legacy_use_ssl_false_only(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, use_ssl=False)
+        assert server.security == ConnectionSecurity.NONE
+
+    def test_legacy_start_ssl_true_only(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=143, start_ssl=True)
+        # use_ssl defaults to None (not set), start_ssl=True → STARTTLS
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_invalid_use_ssl_and_start_ssl_both_true(self):
+        with pytest.raises(ValueError, match="cannot both be true"):
+            EmailServer(user_name="u", password="p", host="h", port=993, use_ssl=True, start_ssl=True)
+
+    def test_security_enum_values(self):
+        assert ConnectionSecurity.TLS.value == "tls"
+        assert ConnectionSecurity.STARTTLS.value == "starttls"
+        assert ConnectionSecurity.NONE.value == "none"
+
+    def test_verify_ssl_default_true(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993)
+        assert server.verify_ssl is True
+
+    def test_verify_ssl_false(self):
+        server = EmailServer(user_name="u", password="p", host="h", port=993, verify_ssl=False)
+        assert server.verify_ssl is False
+
+    def test_masked_preserves_security(self):
+        server = EmailServer(user_name="u", password="secret", host="h", port=143, security="starttls")
+        masked = server.masked()
+        assert masked.security == ConnectionSecurity.STARTTLS
+        assert masked.password == "*" * 8
+
+
+class TestEmailSettingsInit:
+    """Tests for EmailSettings.init() with new security parameters."""
+
+    def test_init_with_security_params(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+            imap_port=143,
+            imap_security=ConnectionSecurity.STARTTLS,
+            smtp_port=587,
+            smtp_security=ConnectionSecurity.STARTTLS,
+        )
+        assert settings.incoming.security == ConnectionSecurity.STARTTLS
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_init_with_legacy_params(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+            imap_ssl=False,
+            smtp_ssl=False,
+            smtp_start_ssl=True,
+        )
+        # imap_ssl=False → use_ssl=False → security=NONE (no start_ssl for IMAP in legacy)
+        assert settings.incoming.security == ConnectionSecurity.NONE
+        # smtp_ssl=False + smtp_start_ssl=True → STARTTLS
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_init_default_is_tls(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+        )
+        assert settings.incoming.security == ConnectionSecurity.TLS
+        assert settings.outgoing.security == ConnectionSecurity.TLS
+
+    def test_init_with_verify_ssl(self):
+        settings = EmailSettings.init(
+            account_name="test",
+            full_name="Test",
+            email_address="test@example.com",
+            user_name="test",
+            password="pass",
+            imap_host="localhost",
+            smtp_host="localhost",
+            imap_verify_ssl=False,
+            smtp_verify_ssl=False,
+        )
+        assert settings.incoming.verify_ssl is False
+        assert settings.outgoing.verify_ssl is False
+
+
+class TestEmailSettingsFromEnv:
+    """Tests for EmailSettings.from_env() with new security env vars."""
+
+    def test_from_env_with_security_vars(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SECURITY", "starttls")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_SECURITY", "starttls")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_PORT", "143")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_PORT", "587")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.STARTTLS
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_from_env_with_legacy_ssl_vars(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SSL", "false")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_SSL", "false")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_START_SSL", "true")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.NONE
+        assert settings.outgoing.security == ConnectionSecurity.STARTTLS
+
+    def test_from_env_security_takes_precedence_over_legacy(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        # New env var takes precedence
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SECURITY", "starttls")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SSL", "true")  # Should be ignored
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.STARTTLS
+
+    def test_from_env_with_imap_verify_ssl(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "localhost")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "localhost")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_VERIFY_SSL", "false")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.verify_ssl is False
+
+    def test_from_env_invalid_security_value_uses_default(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SECURITY", "invalid_value")
+
+        settings = EmailSettings.from_env()
+        assert settings is not None
+        assert settings.incoming.security == ConnectionSecurity.TLS  # Falls back to default
+
+
+class TestImapConnection:
+    """Tests for IMAP connection creation with different security modes."""
+
+    @pytest.mark.asyncio
+    async def test_create_imap_connection_tls(self):
+        server = EmailServer(user_name="u", password="p", host="localhost", port=993, security="tls")
+
+        with patch("mcp_email_server.emails.classic.aioimaplib") as mock_aioimaplib:
+            mock_imap = AsyncMock()
+            mock_imap._client_task = asyncio.Future()
+            mock_imap._client_task.set_result(None)
+            mock_imap.wait_hello_from_server = AsyncMock()
+            mock_aioimaplib.IMAP4_SSL.return_value = mock_imap
+
+            from mcp_email_server.emails.classic import _create_imap_connection
+
+            result = await _create_imap_connection(server)
+
+            mock_aioimaplib.IMAP4_SSL.assert_called_once()
+            assert result is mock_imap
+
+    @pytest.mark.asyncio
+    async def test_create_imap_connection_none(self):
+        server = EmailServer(user_name="u", password="p", host="localhost", port=143, security="none")
+
+        with patch("mcp_email_server.emails.classic.aioimaplib") as mock_aioimaplib:
+            mock_imap = AsyncMock()
+            mock_imap._client_task = asyncio.Future()
+            mock_imap._client_task.set_result(None)
+            mock_imap.wait_hello_from_server = AsyncMock()
+            mock_aioimaplib.IMAP4.return_value = mock_imap
+
+            from mcp_email_server.emails.classic import _create_imap_connection
+
+            result = await _create_imap_connection(server)
+
+            mock_aioimaplib.IMAP4.assert_called_once_with("localhost", 143)
+            assert result is mock_imap
+
+    @pytest.mark.asyncio
+    async def test_create_imap_connection_starttls(self):
+        server = EmailServer(user_name="u", password="p", host="localhost", port=143, security="starttls")
+
+        with (
+            patch("mcp_email_server.emails.classic.aioimaplib") as mock_aioimaplib,
+            patch("mcp_email_server.emails.classic._imap_starttls") as mock_starttls,
+        ):
+            mock_imap = AsyncMock()
+            mock_imap._client_task = asyncio.Future()
+            mock_imap._client_task.set_result(None)
+            mock_imap.wait_hello_from_server = AsyncMock()
+            mock_aioimaplib.IMAP4.return_value = mock_imap
+
+            from mcp_email_server.emails.classic import _create_imap_connection
+
+            result = await _create_imap_connection(server)
+
+            mock_aioimaplib.IMAP4.assert_called_once_with("localhost", 143)
+            mock_starttls.assert_called_once()
+            assert result is mock_imap
+
+
+class TestImapStarttls:
+    """Tests for the _imap_starttls function."""
+
+    @pytest.mark.asyncio
+    async def test_starttls_succeeds(self):
+        from mcp_email_server.emails.classic import _imap_starttls
+
+        mock_imap = MagicMock()
+        mock_protocol = MagicMock()
+        mock_protocol.capabilities = {"STARTTLS", "IMAP4rev1"}
+        mock_protocol.new_tag.return_value = "A001"
+        mock_protocol.loop = asyncio.get_event_loop()
+        mock_protocol.transport = MagicMock()
+
+        # Mock execute to return OK
+        mock_response = MagicMock()
+        mock_response.result = "OK"
+        mock_protocol.execute = AsyncMock(return_value=mock_response)
+        mock_protocol.capability = AsyncMock()
+
+        mock_imap.protocol = mock_protocol
+
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+        mock_tls_transport = MagicMock()
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.start_tls = AsyncMock(return_value=mock_tls_transport)
+
+            await _imap_starttls(mock_imap, ssl_ctx, "localhost")
+
+            # Verify STARTTLS command was sent
+            mock_protocol.execute.assert_called_once()
+            cmd = mock_protocol.execute.call_args[0][0]
+            assert cmd.name == "STARTTLS"
+
+            # Verify transport was upgraded
+            mock_loop.return_value.start_tls.assert_called_once()
+
+            # Verify capabilities were re-fetched
+            mock_protocol.capability.assert_called_once()
+
+            # Verify transport was replaced
+            assert mock_imap.protocol.transport is mock_tls_transport
+
+    @pytest.mark.asyncio
+    async def test_starttls_no_capability_raises(self):
+        from mcp_email_server.emails.classic import _imap_starttls
+
+        mock_imap = MagicMock()
+        mock_imap.protocol.capabilities = {"IMAP4rev1"}  # No STARTTLS
+
+        ssl_ctx = ssl.create_default_context()
+
+        with pytest.raises(OSError, match="does not advertise STARTTLS"):
+            await _imap_starttls(mock_imap, ssl_ctx, "localhost")
+
+    @pytest.mark.asyncio
+    async def test_starttls_command_fails_raises(self):
+        from mcp_email_server.emails.classic import _imap_starttls
+
+        mock_imap = MagicMock()
+        mock_protocol = MagicMock()
+        mock_protocol.capabilities = {"STARTTLS", "IMAP4rev1"}
+        mock_protocol.new_tag.return_value = "A001"
+        mock_protocol.loop = asyncio.get_event_loop()
+
+        mock_response = MagicMock()
+        mock_response.result = "NO"
+        mock_protocol.execute = AsyncMock(return_value=mock_response)
+        mock_imap.protocol = mock_protocol
+
+        ssl_ctx = ssl.create_default_context()
+
+        with pytest.raises(OSError, match="STARTTLS command failed"):
+            await _imap_starttls(mock_imap, ssl_ctx, "localhost")
+
+
+class TestEmailClientSecurity:
+    """Tests for EmailClient with different security modes."""
+
+    def test_client_tls_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=993, security="tls")
+        client = EmailClient(server)
+        assert client.smtp_use_tls is True
+        assert client.smtp_start_tls is False
+
+    def test_client_starttls_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=587, security="starttls")
+        client = EmailClient(server)
+        assert client.smtp_use_tls is False
+        assert client.smtp_start_tls is True
+
+    def test_client_none_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=25, security="none")
+        client = EmailClient(server)
+        assert client.smtp_use_tls is False
+        assert client.smtp_start_tls is False
+
+    def test_client_legacy_compat_smtp_settings(self):
+        from mcp_email_server.emails.classic import EmailClient
+
+        server = EmailServer(user_name="u", password="p", host="h", port=587, use_ssl=False, start_ssl=True)
+        client = EmailClient(server)
+        assert client.smtp_use_tls is False
+        assert client.smtp_start_tls is True
+
+
+class TestImapSslContext:
+    """Tests for IMAP SSL context creation."""
+
+    def test_create_imap_ssl_context_verified(self):
+        from mcp_email_server.emails.classic import _create_imap_ssl_context
+
+        ctx = _create_imap_ssl_context(verify_ssl=True)
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_create_imap_ssl_context_unverified(self):
+        from mcp_email_server.emails.classic import _create_imap_ssl_context
+
+        ctx = _create_imap_ssl_context(verify_ssl=False)
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.verify_mode == ssl.CERT_NONE
+        assert ctx.check_hostname is False
+
+
+class TestTomlBackwardCompat:
+    """Tests for backward compatibility with existing TOML configs."""
+
+    def test_security_takes_precedence_over_legacy(self):
+        """When both `security` and legacy fields are set, `security` wins."""
+        server = EmailServer(user_name="u", password="p", host="h", port=993, security="starttls", use_ssl=True)
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_legacy_toml_format_incoming(self):
+        """Simulate loading a config with old use_ssl/start_ssl fields."""
+        server = EmailServer.model_validate({
+            "user_name": "user",
+            "password": "pass",
+            "host": "127.0.0.1",
+            "port": 1143,
+            "use_ssl": False,
+            "start_ssl": True,
+        })
+        assert server.security == ConnectionSecurity.STARTTLS
+
+    def test_new_toml_format(self):
+        """Simulate loading a config with new security field."""
+        server = EmailServer.model_validate({
+            "user_name": "user",
+            "password": "pass",
+            "host": "127.0.0.1",
+            "port": 1143,
+            "security": "starttls",
+            "verify_ssl": False,
+        })
+        assert server.security == ConnectionSecurity.STARTTLS
+        assert server.verify_ssl is False
+
+    def test_legacy_format_without_explicit_start_ssl(self):
+        """Old configs without start_ssl should default to TLS."""
+        server = EmailServer.model_validate({
+            "user_name": "user",
+            "password": "pass",
+            "host": "imap.gmail.com",
+            "port": 993,
+            "use_ssl": True,
+        })
+        assert server.security == ConnectionSecurity.TLS

--- a/tests/test_save_to_sent.py
+++ b/tests/test_save_to_sent.py
@@ -359,7 +359,7 @@ class TestEmailClientAppendToSent:
             password="test_password",
             host="smtp.example.com",
             port=465,
-            use_ssl=False,
+            security="none",
         )
         client = EmailClient(server)
 
@@ -368,7 +368,7 @@ class TestEmailClientAppendToSent:
             password="test_password",
             host="imap.example.com",
             port=143,
-            use_ssl=False,
+            security="none",
         )
 
         msg = MIMEText("Test body")

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosmtpd"
+version = "1.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "atpublic" },
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/ca/b2b7cc880403ef24be77383edaadfcf0098f5d7b9ddbf3e2c17ef0a6af0d/aiosmtpd-1.4.6.tar.gz", hash = "sha256:5a811826e1a5a06c25ebc3e6c4a704613eb9a1bcf6b78428fbe865f4f6c9a4b8", size = 152775, upload-time = "2024-05-18T11:37:50.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl", hash = "sha256:72c99179ba5aa9ae0abbda6994668239b64a5ce054471955fe75f581d2592475", size = 154263, upload-time = "2024-05-18T11:37:47.877Z" },
+]
+
+[[package]]
 name = "aiosmtplib"
 version = "4.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -57,6 +70,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+]
+
+[[package]]
+name = "atpublic"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/05/e2e131a0debaf0f01b8a1b586f5f11713f6affc3e711b406f15f11eafc92/atpublic-7.0.0.tar.gz", hash = "sha256:466ef10d0c8bbd14fd02a5fbd5a8b6af6a846373d91106d3a07c16d72d96b63e", size = 17801, upload-time = "2025-11-29T05:56:45.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl", hash = "sha256:6702bd9e7245eb4e8220a3e222afcef7f87412154732271ee7deee4433b72b4b", size = 6421, upload-time = "2025-11-29T05:56:44.604Z" },
 ]
 
 [[package]]
@@ -1088,6 +1110,13 @@ dev = [
     { name = "ruff" },
     { name = "tox-uv" },
 ]
+docker = [
+    { name = "pytest-docker" },
+]
+integration = [
+    { name = "aiosmtpd" },
+    { name = "pytest-localserver" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1115,6 +1144,11 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "ruff", specifier = ">=0.9.2" },
     { name = "tox-uv", specifier = ">=1.11.3" },
+]
+docker = [{ name = "pytest-docker", specifier = ">=3.1.0" }]
+integration = [
+    { name = "aiosmtpd", specifier = ">=1.4.0" },
+    { name = "pytest-localserver", specifier = ">=0.9.0" },
 ]
 
 [[package]]
@@ -1983,6 +2017,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-docker"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/05/b7e47dc3e01b505838372e296bd780180b3b699a9a134bb8d6be85f3d567/pytest_docker-3.2.5.tar.gz", hash = "sha256:c9662567522911280b394af4da2edd57facaf644494601fac962ff1e396d7ab6", size = 13717, upload-time = "2025-11-12T13:42:19.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/e4/3a76a393f808edb0ee08ecc25e5c00bce0522a45b8fcf8693ec9441739c8/pytest_docker-3.2.5-py3-none-any.whl", hash = "sha256:79f3d209f928f45d4385cb825944861bc8a8cccd309804d9c9cd63bcef03edba", size = 8724, upload-time = "2025-11-12T13:42:18.631Z" },
+]
+
+[[package]]
+name = "pytest-localserver"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/f0/415ed723f04749c3e3417b51797fc5aebe4149ee4b23997e63e6196708bd/pytest_localserver-0.10.0.tar.gz", hash = "sha256:2607197f390912ab25525d129ac43c3c875049257368b3fe09b5cd03dcc526af", size = 30796, upload-time = "2025-11-24T18:02:11.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/9a/544c5163c56f3e461021bf408c947567f67ec8a83a800efb5b89d808bbae/pytest_localserver-0.10.0-py3-none-any.whl", hash = "sha256:de526dc5fb26395fb7bbf26bfc14dde5ac3390ba8d8c7de42dfa492d65e0c448", size = 19779, upload-time = "2025-11-24T18:02:09.949Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2652,6 +2711,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1115,6 +1115,7 @@ docker = [
 ]
 integration = [
     { name = "aiosmtpd" },
+    { name = "cryptography" },
     { name = "pytest-localserver" },
 ]
 
@@ -1145,10 +1146,11 @@ dev = [
     { name = "ruff", specifier = ">=0.9.2" },
     { name = "tox-uv", specifier = ">=1.11.3" },
 ]
-docker = [{ name = "pytest-docker", specifier = ">=3.1.0" }]
+docker = [{ name = "pytest-docker", specifier = ">=3.2.5" }]
 integration = [
-    { name = "aiosmtpd", specifier = ">=1.4.0" },
-    { name = "pytest-localserver", specifier = ">=0.9.0" },
+    { name = "aiosmtpd", specifier = ">=1.4.6" },
+    { name = "cryptography", specifier = ">=44.0.0" },
+    { name = "pytest-localserver", specifier = ">=0.10.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds comprehensive IMAP STARTTLS support, RFC 8314-compliant connection security configuration, and a modernized Gradio settings UI.

## Changes

### Core: Connection Security
- **`ConnectionSecurity` enum** (`tls`/`starttls`/`none`) replacing ambiguous `use_ssl`/`start_ssl` booleans
- **IMAP STARTTLS** via `asyncio.loop.start_tls()` transport upgrade (aioimaplib has no built-in support)
- **`_create_imap_connection()` factory** — handles TLS, STARTTLS, and plaintext uniformly
- **IMAP `verify_ssl`** support (was SMTP-only before) with shared `_create_imap_ssl_context()`
- **Backward-compatible validator** (`mode="before"`) — explicit `security` takes precedence over legacy `use_ssl`/`start_ssl`; plaintext requires both flags explicitly false (secure by default)

### Configuration
- `MCP_EMAIL_SERVER_IMAP_SECURITY` / `SMTP_SECURITY` env vars
- `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL` env var
- TOML: `emails[].incoming.security` / `emails[].outgoing.security`

### Gradio UI
- **Connection Security dropdown** (replaces SSL/StartSSL checkboxes) with auto-port update
- **Verify SSL Certificate checkbox** for both IMAP and SMTP
- **Edit Existing Account** dropdown — load saved accounts for editing with password masking
- **"Use same security for SMTP" checkbox** — mirrors IMAP security settings to SMTP
- **"Test IMAP" / "Test SMTP" buttons** — verify connection before saving, with user-friendly error messages
- **Clear / New Account button** — reset form for creating new accounts
- Password fields use `type="password"` for screen privacy

### Documentation
- README: env var table with TOML Key column, comprehensive TOML Configuration Reference (single + multi-account), security modes reference, ProtonMail Bridge example

### Tests
- 55 new tests (188 total): enum, backward compat, validator precedence, STARTTLS flow, SSL context, env vars, TOML compat, connection test helpers, update_email
- `make check` + `make test` green

## Breaking Changes

None — `use_ssl`/`start_ssl` fields are preserved as deprecated optional aliases with full backward compatibility.