### PR TITLE
feat: Add move_emails and archive_emails MCP tools

### DIFF
--- a/mcp_email_server/__main__.py
+++ b/mcp_email_server/__main__.py
@@ -1,0 +1,3 @@
+from mcp_email_server.cli import app
+
+app(["stdio"])

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -197,6 +197,51 @@ async def delete_emails(
 
 
 @mcp.tool(
+    description="Move one or more emails from one mailbox to another. Use list_emails_metadata first to get the email_id."
+)
+async def move_emails(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    email_ids: Annotated[
+        list[str],
+        Field(description="List of email_id to move (obtained from list_emails_metadata)."),
+    ],
+    destination_mailbox: Annotated[
+        str,
+        Field(description="The destination mailbox to move emails to (e.g. 'Archive', 'Trash', 'Junk')."),
+    ],
+    source_mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox to move emails from.")] = "INBOX",
+) -> str:
+    handler = dispatch_handler(account_name)
+    moved_ids, failed_ids = await handler.move_emails(email_ids, source_mailbox, destination_mailbox)
+
+    result = f"Successfully moved {len(moved_ids)} email(s) to {destination_mailbox}"
+    if failed_ids:
+        result += f", failed to move {len(failed_ids)} email(s): {', '.join(failed_ids)}"
+    return result
+
+
+@mcp.tool(
+    description="Archive one or more emails (move from INBOX to Archive folder). Use list_emails_metadata first to get the email_id."
+)
+async def archive_emails(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    email_ids: Annotated[
+        list[str],
+        Field(description="List of email_id to archive (obtained from list_emails_metadata)."),
+    ],
+    mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to archive emails from.")] = "INBOX",
+    archive_folder: Annotated[str, Field(default="Archive", description="The archive folder name (default: 'Archive').")] = "Archive",
+) -> str:
+    handler = dispatch_handler(account_name)
+    moved_ids, failed_ids = await handler.move_emails(email_ids, mailbox, archive_folder)
+
+    result = f"Successfully archived {len(moved_ids)} email(s)"
+    if failed_ids:
+        result += f", failed to archive {len(failed_ids)} email(s): {', '.join(failed_ids)}"
+    return result
+
+
+@mcp.tool(
     description="Download an email attachment and save it to the specified path. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
 )
 async def download_attachment(

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -246,6 +246,28 @@ async def archive_emails(
 
 
 @mcp.tool(
+    description="Create an IMAP folder/mailbox. Supports hierarchical folder names (e.g. 'Projects/Active') and automatically creates parent folders if needed."
+)
+async def create_folder(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    folder_name: Annotated[
+        str,
+        Field(description="The name of the folder to create (e.g. 'Archive', 'Projects/Active')."),
+    ],
+) -> str:
+    handler = dispatch_handler(account_name)
+    return await handler.create_folder(folder_name)
+
+
+@mcp.tool(description="List all IMAP folders/mailboxes for an email account.")
+async def list_folders(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+) -> list[str]:
+    handler = dispatch_handler(account_name)
+    return await handler.list_folders()
+
+
+@mcp.tool(
     description="Download an email attachment and save it to the specified path. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
 )
 async def download_attachment(

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -209,7 +209,9 @@ async def move_emails(
         str,
         Field(description="The destination mailbox to move emails to (e.g. 'Archive', 'Trash', 'Junk')."),
     ],
-    source_mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox to move emails from.")] = "INBOX",
+    source_mailbox: Annotated[
+        str, Field(default="INBOX", description="The source mailbox to move emails from.")
+    ] = "INBOX",
 ) -> str:
     handler = dispatch_handler(account_name)
     moved_ids, failed_ids = await handler.move_emails(email_ids, source_mailbox, destination_mailbox)
@@ -230,7 +232,9 @@ async def archive_emails(
         Field(description="List of email_id to archive (obtained from list_emails_metadata)."),
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to archive emails from.")] = "INBOX",
-    archive_folder: Annotated[str, Field(default="Archive", description="The archive folder name (default: 'Archive').")] = "Archive",
+    archive_folder: Annotated[
+        str, Field(default="Archive", description="The archive folder name (default: 'Archive').")
+    ] = "Archive",
 ) -> str:
     handler = dispatch_handler(account_name)
     moved_ids, failed_ids = await handler.move_emails(email_ids, mailbox, archive_folder)

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -86,6 +86,14 @@ class EmailHandler(abc.ABC):
         """
 
     @abc.abstractmethod
+    async def move_emails(
+        self, email_ids: list[str], source_mailbox: str, destination_mailbox: str
+    ) -> tuple[list[str], list[str]]:
+        """
+        Move emails from one mailbox to another. Returns (moved_ids, failed_ids)
+        """
+
+    @abc.abstractmethod
     async def download_attachment(
         self,
         email_id: str,

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -113,3 +113,25 @@ class EmailHandler(abc.ABC):
         Returns:
             AttachmentDownloadResponse with download result information.
         """
+
+    @abc.abstractmethod
+    async def create_folder(self, folder_name: str) -> str:
+        """
+        Create an IMAP folder/mailbox. Creates parent folders if needed
+        for hierarchical names (e.g. "Parent/Child").
+
+        Args:
+            folder_name: The name of the folder to create.
+
+        Returns:
+            A status message indicating success.
+        """
+
+    @abc.abstractmethod
+    async def list_folders(self) -> list[str]:
+        """
+        List all IMAP folders/mailboxes for the account.
+
+        Returns:
+            A list of folder names.
+        """

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1019,6 +1019,83 @@ class EmailClient:
 
         return moved_ids, failed_ids
 
+    async def create_folder(self, folder_name: str) -> str:
+        """Create an IMAP folder. Creates parent folders if needed for hierarchical names."""
+        imap = self._imap_connect()
+
+        try:
+            await imap._client_task
+            await imap.wait_hello_from_server()
+            await imap.login(self.email_server.user_name, self.email_server.password)
+            await _send_imap_id(imap)
+
+            # Determine the hierarchy delimiter by listing the root
+            _, list_data = await imap.list('""', '""')
+            delimiter = "/"
+            for item in list_data:
+                item_str = item.decode("utf-8") if isinstance(item, bytes) else str(item)
+                # Parse delimiter from LIST response: (flags) "delimiter" "name"
+                parts = item_str.split('"')
+                if len(parts) >= 2:
+                    delimiter = parts[1]
+                    break
+
+            # Split folder name on the delimiter and create parent folders first
+            folder_parts = folder_name.split(delimiter)
+            created = []
+            for i in range(1, len(folder_parts) + 1):
+                partial = delimiter.join(folder_parts[:i])
+                result = await imap.create(_quote_mailbox(partial))
+                status = result[0] if isinstance(result, tuple) else result
+                if str(status).upper() == "OK":
+                    # Subscribe so the folder is visible in email clients
+                    await imap.subscribe(_quote_mailbox(partial))
+                    created.append(partial)
+                    logger.info(f"Created and subscribed folder: '{partial}'")
+                else:
+                    # Folder may already exist — that's fine for parent folders
+                    logger.debug(f"Create folder '{partial}' returned: {status}")
+
+            if not created:
+                return f"Folder '{folder_name}' already exists"
+            if len(created) == 1:
+                return f"Created folder '{folder_name}'"
+            return f"Created folders: {', '.join(created)}"
+
+        finally:
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
+    async def list_folders(self) -> list[str]:
+        """List all IMAP folders/mailboxes."""
+        imap = self._imap_connect()
+
+        try:
+            await imap._client_task
+            await imap.wait_hello_from_server()
+            await imap.login(self.email_server.user_name, self.email_server.password)
+            await _send_imap_id(imap)
+
+            _, folders_data = await imap.list('""', "*")
+            folders = []
+            for item in folders_data:
+                item_str = item.decode("utf-8") if isinstance(item, bytes) else str(item)
+                # IMAP LIST response format: (flags) "delimiter" "name"
+                parts = item_str.split('"')
+                if len(parts) >= 3:
+                    folder_name = parts[-2]
+                    folders.append(folder_name)
+
+            return sorted(folders)
+
+        finally:
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
 
 class ClassicEmailHandler(EmailHandler):
     def __init__(self, email_settings: EmailSettings):
@@ -1153,6 +1230,14 @@ class ClassicEmailHandler(EmailHandler):
     ) -> tuple[list[str], list[str]]:
         """Move emails from one mailbox to another. Returns (moved_ids, failed_ids)."""
         return await self.incoming_client.move_emails(email_ids, source_mailbox, destination_mailbox)
+
+    async def create_folder(self, folder_name: str) -> str:
+        """Create an IMAP folder/mailbox."""
+        return await self.incoming_client.create_folder(folder_name)
+
+    async def list_folders(self) -> list[str]:
+        """List all IMAP folders/mailboxes."""
+        return await self.incoming_client.list_folders()
 
     async def download_attachment(
         self,

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -986,10 +986,8 @@ class EmailClient:
 
             # Verify destination mailbox exists before moving any emails
             dest_quoted = _quote_mailbox(destination_mailbox)
-            response = await imap.list("", dest_quoted)
-            if response.result != "OK" or not any(
-                line for line in response.lines if line and destination_mailbox in str(line)
-            ):
+            select_response = await imap.select(dest_quoted)
+            if select_response.result != "OK":
                 raise OSError(
                     f"Destination mailbox '{destination_mailbox}' does not exist. Create it first before moving emails."
                 )

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -970,6 +970,39 @@ class EmailClient:
 
         return deleted_ids, failed_ids
 
+    async def move_emails(
+        self, email_ids: list[str], source_mailbox: str, destination_mailbox: str
+    ) -> tuple[list[str], list[str]]:
+        """Move emails by their UIDs from one mailbox to another. Returns (moved_ids, failed_ids)."""
+        imap = self._imap_connect()
+        moved_ids = []
+        failed_ids = []
+
+        try:
+            await imap._client_task
+            await imap.wait_hello_from_server()
+            await imap.login(self.email_server.user_name, self.email_server.password)
+            await _send_imap_id(imap)
+            await imap.select(_quote_mailbox(source_mailbox))
+
+            for email_id in email_ids:
+                try:
+                    await imap.uid("copy", email_id, _quote_mailbox(destination_mailbox))
+                    await imap.uid("store", email_id, "+FLAGS", r"(\Deleted)")
+                    moved_ids.append(email_id)
+                except Exception as e:
+                    logger.error(f"Failed to move email {email_id}: {e}")
+                    failed_ids.append(email_id)
+
+            await imap.expunge()
+        finally:
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
+        return moved_ids, failed_ids
+
 
 class ClassicEmailHandler(EmailHandler):
     def __init__(self, email_settings: EmailSettings):
@@ -1098,6 +1131,12 @@ class ClassicEmailHandler(EmailHandler):
     async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """Delete emails by their UIDs. Returns (deleted_ids, failed_ids)."""
         return await self.incoming_client.delete_emails(email_ids, mailbox)
+
+    async def move_emails(
+        self, email_ids: list[str], source_mailbox: str, destination_mailbox: str
+    ) -> tuple[list[str], list[str]]:
+        """Move emails from one mailbox to another. Returns (moved_ids, failed_ids)."""
+        return await self.incoming_client.move_emails(email_ids, source_mailbox, destination_mailbox)
 
     async def download_attachment(
         self,

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -983,18 +983,37 @@ class EmailClient:
             await imap.wait_hello_from_server()
             await imap.login(self.email_server.user_name, self.email_server.password)
             await _send_imap_id(imap)
+
+            # Verify destination mailbox exists before moving any emails
+            dest_quoted = _quote_mailbox(destination_mailbox)
+            response = await imap.list("", dest_quoted)
+            if response.result != "OK" or not any(
+                line for line in response.lines if line and destination_mailbox in str(line)
+            ):
+                raise OSError(
+                    f"Destination mailbox '{destination_mailbox}' does not exist. "
+                    f"Create it first before moving emails."
+                )
+
             await imap.select(_quote_mailbox(source_mailbox))
 
             for email_id in email_ids:
                 try:
-                    await imap.uid("copy", email_id, _quote_mailbox(destination_mailbox))
+                    copy_response = await imap.uid("copy", email_id, dest_quoted)
+                    if copy_response.result != "OK":
+                        logger.error(
+                            f"COPY failed for email {email_id}: {copy_response.result} {copy_response.lines}"
+                        )
+                        failed_ids.append(email_id)
+                        continue
                     await imap.uid("store", email_id, "+FLAGS", r"(\Deleted)")
                     moved_ids.append(email_id)
                 except Exception as e:
                     logger.error(f"Failed to move email {email_id}: {e}")
                     failed_ids.append(email_id)
 
-            await imap.expunge()
+            if moved_ids:
+                await imap.expunge()
         finally:
             try:
                 await imap.logout()

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -991,8 +991,7 @@ class EmailClient:
                 line for line in response.lines if line and destination_mailbox in str(line)
             ):
                 raise OSError(
-                    f"Destination mailbox '{destination_mailbox}' does not exist. "
-                    f"Create it first before moving emails."
+                    f"Destination mailbox '{destination_mailbox}' does not exist. Create it first before moving emails."
                 )
 
             await imap.select(_quote_mailbox(source_mailbox))
@@ -1001,9 +1000,7 @@ class EmailClient:
                 try:
                     copy_response = await imap.uid("copy", email_id, dest_quoted)
                     if copy_response.result != "OK":
-                        logger.error(
-                            f"COPY failed for email {email_id}: {copy_response.result} {copy_response.lines}"
-                        )
+                        logger.error(f"COPY failed for email {email_id}: {copy_response.result} {copy_response.lines}")
                         failed_ids.append(email_id)
                         continue
                     await imap.uid("store", email_id, "+FLAGS", r"(\Deleted)")

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -275,6 +275,38 @@ class TestClassicEmailHandler:
             mock_delete.assert_called_once_with(["789"], "Archive")
 
     @pytest.mark.asyncio
+    async def test_move_emails(self, classic_handler):
+        """Test move_emails method."""
+        mock_move = AsyncMock(return_value=(["123", "456"], []))
+
+        with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+            moved_ids, failed_ids = await classic_handler.move_emails(
+                email_ids=["123", "456"],
+                source_mailbox="INBOX",
+                destination_mailbox="Archive",
+            )
+
+            assert moved_ids == ["123", "456"]
+            assert failed_ids == []
+            mock_move.assert_called_once_with(["123", "456"], "INBOX", "Archive")
+
+    @pytest.mark.asyncio
+    async def test_move_emails_with_failures(self, classic_handler):
+        """Test move_emails method with some failures."""
+        mock_move = AsyncMock(return_value=(["123"], ["456"]))
+
+        with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+            moved_ids, failed_ids = await classic_handler.move_emails(
+                email_ids=["123", "456"],
+                source_mailbox="INBOX",
+                destination_mailbox="Trash",
+            )
+
+            assert moved_ids == ["123"]
+            assert failed_ids == ["456"]
+            mock_move.assert_called_once_with(["123", "456"], "INBOX", "Trash")
+
+    @pytest.mark.asyncio
     async def test_download_attachment(self, classic_handler, tmp_path):
         """Test download_attachment method."""
         save_path = str(tmp_path / "downloaded_attachment.pdf")

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -330,19 +330,17 @@ class TestEmailClient:
 
 class TestMoveEmails:
     @staticmethod
-    def _mock_list_response(mailbox_name):
-        """Create a mock LIST response indicating the mailbox exists."""
+    def _mock_select_ok():
+        """Create a mock SELECT response indicating the mailbox exists."""
         response = MagicMock()
         response.result = "OK"
-        response.lines = [f'(\\HasNoChildren) "/" "{mailbox_name}"']
         return response
 
     @staticmethod
-    def _mock_list_response_empty():
-        """Create a mock LIST response indicating no matching mailbox."""
+    def _mock_select_no():
+        """Create a mock SELECT response indicating the mailbox does not exist."""
         response = MagicMock()
-        response.result = "OK"
-        response.lines = []
+        response.result = "NO"
         return response
 
     @staticmethod
@@ -369,8 +367,7 @@ class TestMoveEmails:
         mock_imap._client_task.set_result(None)
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
-        mock_imap.select = AsyncMock()
-        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Archive"))
+        mock_imap.select = AsyncMock(return_value=self._mock_select_ok())
         mock_imap.uid = AsyncMock(return_value=self._mock_uid_response_ok())
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock()
@@ -392,7 +389,7 @@ class TestMoveEmails:
         mock_imap._client_task.set_result(None)
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
-        mock_imap.list = AsyncMock(return_value=self._mock_list_response_empty())
+        mock_imap.select = AsyncMock(return_value=self._mock_select_no())
         mock_imap.uid = AsyncMock()
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock()
@@ -413,8 +410,7 @@ class TestMoveEmails:
         mock_imap._client_task.set_result(None)
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
-        mock_imap.select = AsyncMock()
-        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Archive"))
+        mock_imap.select = AsyncMock(return_value=self._mock_select_ok())
         mock_imap.uid = AsyncMock(return_value=self._mock_uid_response_no())
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock()
@@ -437,8 +433,7 @@ class TestMoveEmails:
         mock_imap._client_task.set_result(None)
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
-        mock_imap.select = AsyncMock()
-        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Trash"))
+        mock_imap.select = AsyncMock(return_value=self._mock_select_ok())
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock()
 
@@ -468,8 +463,7 @@ class TestMoveEmails:
         mock_imap._client_task.set_result(None)
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
-        mock_imap.select = AsyncMock()
-        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Archive"))
+        mock_imap.select = AsyncMock(return_value=self._mock_select_ok())
         mock_imap.uid = AsyncMock(return_value=self._mock_uid_response_ok())
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock(side_effect=Exception("Connection lost"))

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -370,7 +370,7 @@ class TestMoveEmails:
             call_count += 1
             # First email succeeds (copy + store), second email fails on copy
             if call_count == 3:  # third call = copy for second email
-                raise Exception("IMAP error")
+                raise OSError("IMAP error")
             return ("OK", [])
 
         mock_imap.uid = AsyncMock(side_effect=uid_side_effect)

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -854,3 +854,111 @@ class TestBatchFetchHeaders:
         assert len(result) == 2
         assert result["100"]["subject"] == "First"
         assert result["200"]["subject"] == "Second"
+
+
+class TestCreateFolder:
+    @pytest.mark.asyncio
+    async def test_create_folder_simple(self, email_client):
+        """Test creating a simple (non-hierarchical) folder."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\HasNoChildren) "/" "INBOX"']))
+        mock_imap.create = AsyncMock(return_value=("OK", [b"CREATE completed"]))
+        mock_imap.subscribe = AsyncMock(return_value=("OK", [b"SUBSCRIBE completed"]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.create_folder("Archive")
+
+        assert "Archive" in result
+        mock_imap.create.assert_called_once_with('"Archive"')
+        mock_imap.subscribe.assert_called_once_with('"Archive"')
+        mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_folder_hierarchical(self, email_client):
+        """Test creating a hierarchical folder creates parent folders first."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\HasNoChildren) "/" "INBOX"']))
+        mock_imap.create = AsyncMock(return_value=("OK", [b"CREATE completed"]))
+        mock_imap.subscribe = AsyncMock(return_value=("OK", [b"SUBSCRIBE completed"]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            await email_client.create_folder("02 areas/VEA bestuur")
+
+        assert mock_imap.create.call_count == 2
+        mock_imap.create.assert_any_call('"02 areas"')
+        mock_imap.create.assert_any_call('"02 areas/VEA bestuur"')
+        assert mock_imap.subscribe.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_create_folder_already_exists(self, email_client):
+        """Test creating a folder that already exists returns appropriate message."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\HasNoChildren) "/" "INBOX"']))
+        mock_imap.create = AsyncMock(return_value=("NO", [b"Mailbox already exists"]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.create_folder("INBOX")
+
+        assert "already exists" in result
+
+
+class TestListFolders:
+    @pytest.mark.asyncio
+    async def test_list_folders(self, email_client):
+        """Test listing all IMAP folders."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(
+            return_value=(
+                "OK",
+                [
+                    b'(\\HasNoChildren) "/" "INBOX"',
+                    b'(\\HasNoChildren) "/" "Archive"',
+                    b'(\\HasNoChildren \\Sent) "/" "Sent"',
+                    b'(\\HasChildren) "/" "Projects"',
+                    b'(\\HasNoChildren) "/" "Projects/Active"',
+                ],
+            )
+        )
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            folders = await email_client.list_folders()
+
+        assert folders == ["Archive", "INBOX", "Projects", "Projects/Active", "Sent"]
+        mock_imap.login.assert_called_once()
+        mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_folders_empty(self, email_client):
+        """Test listing folders when server returns empty list."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", []))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            folders = await email_client.list_folders()
+
+        assert folders == []

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -329,6 +329,38 @@ class TestEmailClient:
 
 
 class TestMoveEmails:
+    @staticmethod
+    def _mock_list_response(mailbox_name):
+        """Create a mock LIST response indicating the mailbox exists."""
+        response = MagicMock()
+        response.result = "OK"
+        response.lines = [f'(\\HasNoChildren) "/" "{mailbox_name}"']
+        return response
+
+    @staticmethod
+    def _mock_list_response_empty():
+        """Create a mock LIST response indicating no matching mailbox."""
+        response = MagicMock()
+        response.result = "OK"
+        response.lines = []
+        return response
+
+    @staticmethod
+    def _mock_uid_response_ok():
+        """Create a mock UID response with OK result."""
+        response = MagicMock()
+        response.result = "OK"
+        response.lines = []
+        return response
+
+    @staticmethod
+    def _mock_uid_response_no():
+        """Create a mock UID response with NO result."""
+        response = MagicMock()
+        response.result = "NO"
+        response.lines = ["TRYCREATE"]
+        return response
+
     @pytest.mark.asyncio
     async def test_move_emails_success(self, email_client):
         """Test moving emails via IMAP copy+delete."""
@@ -338,7 +370,8 @@ class TestMoveEmails:
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
         mock_imap.select = AsyncMock()
-        mock_imap.uid = AsyncMock(return_value=("OK", []))
+        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Archive"))
+        mock_imap.uid = AsyncMock(return_value=self._mock_uid_response_ok())
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock()
 
@@ -352,6 +385,51 @@ class TestMoveEmails:
             mock_imap.logout.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_move_emails_destination_not_exists(self, email_client):
+        """Test that moving to a non-existent mailbox raises an error without deleting emails."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=self._mock_list_response_empty())
+        mock_imap.uid = AsyncMock()
+        mock_imap.expunge = AsyncMock()
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with pytest.raises(OSError, match="does not exist"):
+                await email_client.move_emails(["100", "200"], "INBOX", "Nonexistent")
+
+            # Verify no emails were touched
+            mock_imap.uid.assert_not_called()
+            mock_imap.expunge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_move_emails_copy_failure_no_delete(self, email_client):
+        """Test that a failed COPY does not delete the email from the source."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Archive"))
+        mock_imap.uid = AsyncMock(return_value=self._mock_uid_response_no())
+        mock_imap.expunge = AsyncMock()
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            moved_ids, failed_ids = await email_client.move_emails(["100"], "INBOX", "Archive")
+
+            assert moved_ids == []
+            assert failed_ids == ["100"]
+            # Only 1 call (the failed copy), no store call
+            assert mock_imap.uid.call_count == 1
+            # No expunge since nothing was moved
+            mock_imap.expunge.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_move_emails_partial_failure(self, email_client):
         """Test moving emails where some fail."""
         mock_imap = AsyncMock()
@@ -360,6 +438,7 @@ class TestMoveEmails:
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
         mock_imap.select = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Trash"))
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock()
 
@@ -371,7 +450,7 @@ class TestMoveEmails:
             # First email succeeds (copy + store), second email fails on copy
             if call_count == 3:  # third call = copy for second email
                 raise OSError("IMAP error")
-            return ("OK", [])
+            return self._mock_uid_response_ok()
 
         mock_imap.uid = AsyncMock(side_effect=uid_side_effect)
 
@@ -390,7 +469,8 @@ class TestMoveEmails:
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock()
         mock_imap.select = AsyncMock()
-        mock_imap.uid = AsyncMock(return_value=("OK", []))
+        mock_imap.list = AsyncMock(return_value=self._mock_list_response("Archive"))
+        mock_imap.uid = AsyncMock(return_value=self._mock_uid_response_ok())
         mock_imap.expunge = AsyncMock()
         mock_imap.logout = AsyncMock(side_effect=Exception("Connection lost"))
 

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -343,9 +343,7 @@ class TestMoveEmails:
         mock_imap.logout = AsyncMock()
 
         with patch.object(email_client, "imap_class", return_value=mock_imap):
-            moved_ids, failed_ids = await email_client.move_emails(
-                ["100", "200"], "INBOX", "Archive"
-            )
+            moved_ids, failed_ids = await email_client.move_emails(["100", "200"], "INBOX", "Archive")
 
             assert moved_ids == ["100", "200"]
             assert failed_ids == []
@@ -378,9 +376,7 @@ class TestMoveEmails:
         mock_imap.uid = AsyncMock(side_effect=uid_side_effect)
 
         with patch.object(email_client, "imap_class", return_value=mock_imap):
-            moved_ids, failed_ids = await email_client.move_emails(
-                ["100", "200"], "INBOX", "Trash"
-            )
+            moved_ids, failed_ids = await email_client.move_emails(["100", "200"], "INBOX", "Trash")
 
             assert moved_ids == ["100"]
             assert failed_ids == ["200"]
@@ -399,9 +395,7 @@ class TestMoveEmails:
         mock_imap.logout = AsyncMock(side_effect=Exception("Connection lost"))
 
         with patch.object(email_client, "imap_class", return_value=mock_imap):
-            moved_ids, failed_ids = await email_client.move_emails(
-                ["100"], "INBOX", "Archive"
-            )
+            moved_ids, failed_ids = await email_client.move_emails(["100"], "INBOX", "Archive")
 
             assert moved_ids == ["100"]
             assert failed_ids == []

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -328,6 +328,85 @@ class TestEmailClient:
             assert "bcc@example.com" in recipients
 
 
+class TestMoveEmails:
+    @pytest.mark.asyncio
+    async def test_move_emails_success(self, email_client):
+        """Test moving emails via IMAP copy+delete."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.uid = AsyncMock(return_value=("OK", []))
+        mock_imap.expunge = AsyncMock()
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            moved_ids, failed_ids = await email_client.move_emails(
+                ["100", "200"], "INBOX", "Archive"
+            )
+
+            assert moved_ids == ["100", "200"]
+            assert failed_ids == []
+            assert mock_imap.uid.call_count == 4  # 2 copy + 2 store
+            mock_imap.expunge.assert_called_once()
+            mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_move_emails_partial_failure(self, email_client):
+        """Test moving emails where some fail."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.expunge = AsyncMock()
+        mock_imap.logout = AsyncMock()
+
+        call_count = 0
+
+        async def uid_side_effect(*args):
+            nonlocal call_count
+            call_count += 1
+            # First email succeeds (copy + store), second email fails on copy
+            if call_count == 3:  # third call = copy for second email
+                raise Exception("IMAP error")
+            return ("OK", [])
+
+        mock_imap.uid = AsyncMock(side_effect=uid_side_effect)
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            moved_ids, failed_ids = await email_client.move_emails(
+                ["100", "200"], "INBOX", "Trash"
+            )
+
+            assert moved_ids == ["100"]
+            assert failed_ids == ["200"]
+
+    @pytest.mark.asyncio
+    async def test_move_emails_logout_error_handled(self, email_client):
+        """Test that logout errors are handled gracefully."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.select = AsyncMock()
+        mock_imap.uid = AsyncMock(return_value=("OK", []))
+        mock_imap.expunge = AsyncMock()
+        mock_imap.logout = AsyncMock(side_effect=Exception("Connection lost"))
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            moved_ids, failed_ids = await email_client.move_emails(
+                ["100"], "INBOX", "Archive"
+            )
+
+            assert moved_ids == ["100"]
+            assert failed_ids == []
+
+
 class TestSendEmailMessageIdAndDate:
     @pytest.mark.asyncio
     async def test_send_email_sets_message_id_and_date(self, email_client):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -5,11 +5,13 @@ import pytest
 
 from mcp_email_server.app import (
     add_email_account,
+    archive_emails,
     delete_emails,
     download_attachment,
     get_emails_content,
     list_available_accounts,
     list_emails_metadata,
+    move_emails,
     send_email,
 )
 from mcp_email_server.config import EmailServer, EmailSettings, ProviderSettings
@@ -435,6 +437,101 @@ class TestMcpTools:
 
             assert result == "Successfully deleted 1 email(s)"
             mock_handler.delete_emails.assert_called_once_with(["12345"], "Trash")
+
+    @pytest.mark.asyncio
+    async def test_move_emails(self):
+        """Test move_emails MCP tool."""
+        mock_handler = AsyncMock()
+        mock_handler.move_emails.return_value = (["12345", "12346"], [])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await move_emails(
+                account_name="test_account",
+                email_ids=["12345", "12346"],
+                destination_mailbox="Archive",
+            )
+
+            assert result == "Successfully moved 2 email(s) to Archive"
+            mock_handler.move_emails.assert_called_once_with(["12345", "12346"], "INBOX", "Archive")
+
+    @pytest.mark.asyncio
+    async def test_move_emails_with_failures(self):
+        """Test move_emails MCP tool with some failures."""
+        mock_handler = AsyncMock()
+        mock_handler.move_emails.return_value = (["12345"], ["12346", "12347"])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await move_emails(
+                account_name="test_account",
+                email_ids=["12345", "12346", "12347"],
+                destination_mailbox="Trash",
+            )
+
+            assert result == "Successfully moved 1 email(s) to Trash, failed to move 2 email(s): 12346, 12347"
+            mock_handler.move_emails.assert_called_once_with(["12345", "12346", "12347"], "INBOX", "Trash")
+
+    @pytest.mark.asyncio
+    async def test_move_emails_with_source_mailbox(self):
+        """Test move_emails MCP tool with custom source mailbox."""
+        mock_handler = AsyncMock()
+        mock_handler.move_emails.return_value = (["12345"], [])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await move_emails(
+                account_name="test_account",
+                email_ids=["12345"],
+                destination_mailbox="Trash",
+                source_mailbox="Archive",
+            )
+
+            assert result == "Successfully moved 1 email(s) to Trash"
+            mock_handler.move_emails.assert_called_once_with(["12345"], "Archive", "Trash")
+
+    @pytest.mark.asyncio
+    async def test_archive_emails(self):
+        """Test archive_emails MCP tool."""
+        mock_handler = AsyncMock()
+        mock_handler.move_emails.return_value = (["12345", "12346"], [])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await archive_emails(
+                account_name="test_account",
+                email_ids=["12345", "12346"],
+            )
+
+            assert result == "Successfully archived 2 email(s)"
+            mock_handler.move_emails.assert_called_once_with(["12345", "12346"], "INBOX", "Archive")
+
+    @pytest.mark.asyncio
+    async def test_archive_emails_with_failures(self):
+        """Test archive_emails MCP tool with some failures."""
+        mock_handler = AsyncMock()
+        mock_handler.move_emails.return_value = (["12345"], ["12346"])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await archive_emails(
+                account_name="test_account",
+                email_ids=["12345", "12346"],
+            )
+
+            assert result == "Successfully archived 1 email(s), failed to archive 1 email(s): 12346"
+            mock_handler.move_emails.assert_called_once_with(["12345", "12346"], "INBOX", "Archive")
+
+    @pytest.mark.asyncio
+    async def test_archive_emails_custom_folder(self):
+        """Test archive_emails MCP tool with custom archive folder."""
+        mock_handler = AsyncMock()
+        mock_handler.move_emails.return_value = (["12345"], [])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await archive_emails(
+                account_name="test_account",
+                email_ids=["12345"],
+                archive_folder="Archives/2026",
+            )
+
+            assert result == "Successfully archived 1 email(s)"
+            mock_handler.move_emails.assert_called_once_with(["12345"], "INBOX", "Archives/2026")
 
     @pytest.mark.asyncio
     async def test_download_attachment_disabled(self):


### PR DESCRIPTION
## Summary
- Add `move_emails` tool to move emails between IMAP mailboxes (uses COPY + store \Deleted + EXPUNGE)
- Add `archive_emails` convenience tool to move emails from INBOX to Archive folder
- Add abstract `move_emails` method to `EmailHandler` base class with implementation in `ClassicEmailHandler` and `EmailClient`
- Add `__main__.py` for `python -m mcp_email_server` support

## Motivation
Currently the only way to remove emails from the inbox is to delete them permanently. Many users (and AI assistants) need the ability to **archive** emails — moving them out of the inbox without destroying them. This is a fundamental IMAP operation that was missing.

## Test plan
- [ ] Verify `move_emails` correctly copies emails to destination mailbox and removes from source
- [ ] Verify `archive_emails` moves emails to Archive folder
- [ ] Test with different IMAP providers (Gmail, mailbox.org, etc.)
- [ ] Verify error handling for invalid mailbox names and failed moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)