### PR TITLE
refactor: Remove get_email_count, derive total from search results

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -4,7 +4,6 @@ import mimetypes
 import re
 import ssl
 import time
-
 from datetime import datetime, timezone
 from email.header import Header
 from email.mime.application import MIMEApplication

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -4,7 +4,7 @@ import mimetypes
 import re
 import ssl
 import time
-from collections.abc import AsyncGenerator
+
 from datetime import datetime, timezone
 from email.header import Header
 from email.mime.application import MIMEApplication
@@ -414,50 +414,7 @@ class EmailClient:
 
         return results
 
-    async def get_email_count(
-        self,
-        before: datetime | None = None,
-        since: datetime | None = None,
-        subject: str | None = None,
-        from_address: str | None = None,
-        to_address: str | None = None,
-        mailbox: str = "INBOX",
-        seen: bool | None = None,
-        flagged: bool | None = None,
-        answered: bool | None = None,
-    ) -> int:
-        imap = self._imap_connect()
-        try:
-            # Wait for the connection to be established
-            await imap._client_task
-            await imap.wait_hello_from_server()
-
-            # Login and select inbox
-            await imap.login(self.email_server.user_name, self.email_server.password.get_secret_value())
-            await _send_imap_id(imap)
-            await imap.select(_quote_mailbox(mailbox))
-            search_criteria = self._build_search_criteria(
-                before,
-                since,
-                subject,
-                from_address=from_address,
-                to_address=to_address,
-                seen=seen,
-                flagged=flagged,
-                answered=answered,
-            )
-            logger.info(f"Count: Search criteria: {search_criteria}")
-            # Search for messages and count them - use UID SEARCH for consistency
-            _, messages = await imap.uid_search(*search_criteria)
-            return len(messages[0].split())
-        finally:
-            # Ensure we logout properly
-            try:
-                await imap.logout()
-            except Exception as e:
-                logger.info(f"Error during logout: {e}")
-
-    async def get_emails_metadata_stream(
+    async def get_emails_metadata(
         self,
         page: int = 1,
         page_size: int = 10,
@@ -471,7 +428,7 @@ class EmailClient:
         seen: bool | None = None,
         flagged: bool | None = None,
         answered: bool | None = None,
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    ) -> tuple[int, list[dict[str, Any]]]:
         imap = self._imap_connect()
         try:
             # Wait for the connection to be established
@@ -501,7 +458,7 @@ class EmailClient:
             # Handle empty or None responses
             if not messages or not messages[0]:
                 logger.warning("No messages returned from search")
-                return
+                return 0, []
 
             email_ids = messages[0].split()
             logger.info(f"Found {len(email_ids)} email IDs")
@@ -520,7 +477,7 @@ class EmailClient:
 
             if not page_uids:
                 logger.info(f"Phase 1 (dates): {len(uid_dates)} UIDs in {fetch_dates_elapsed:.2f}s, page {page} empty")
-                return
+                return len(email_ids), []
 
             # Phase 2: Batch fetch headers for requested page only
             fetch_headers_start = time.perf_counter()
@@ -532,10 +489,9 @@ class EmailClient:
                 f"{fetch_headers_elapsed:.2f}s headers ({len(page_uids)} UIDs)"
             )
 
-            # Yield in sorted order
-            for uid in page_uids:
-                if uid in metadata_by_uid:
-                    yield metadata_by_uid[uid]
+            # Collect page results in sorted order
+            page_emails = [metadata_by_uid[uid] for uid in page_uids if uid in metadata_by_uid]
+            return len(email_ids), page_emails
         finally:
             try:
                 await imap.logout()
@@ -1009,8 +965,7 @@ class ClassicEmailHandler(EmailHandler):
         flagged: bool | None = None,
         answered: bool | None = None,
     ) -> EmailMetadataPageResponse:
-        emails = []
-        async for email_data in self.incoming_client.get_emails_metadata_stream(
+        total, email_dicts = await self.incoming_client.get_emails_metadata(
             page,
             page_size,
             before,
@@ -1023,19 +978,8 @@ class ClassicEmailHandler(EmailHandler):
             seen,
             flagged,
             answered,
-        ):
-            emails.append(EmailMetadata.from_email(email_data))
-        total = await self.incoming_client.get_email_count(
-            before,
-            since,
-            subject,
-            from_address=from_address,
-            to_address=to_address,
-            mailbox=mailbox,
-            seen=seen,
-            flagged=flagged,
-            answered=answered,
         )
+        emails = [EmailMetadata.from_email(d) for d in email_dicts]
         return EmailMetadataPageResponse(
             page=page,
             page_size=page_size,

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -70,57 +70,41 @@ class TestClassicEmailHandler:
             "attachments": [],
         }
 
-        # Mock the get_emails_stream method to yield our test data
-        mock_stream = AsyncMock()
-        mock_stream.__aiter__.return_value = [email_data]
+        # Mock get_emails_metadata to return (total, email_dicts)
+        mock_get_metadata = AsyncMock(return_value=(1, [email_data]))
 
-        # Mock the get_email_count method
-        mock_count = AsyncMock(return_value=1)
+        # Apply the mock
+        with patch.object(classic_handler.incoming_client, "get_emails_metadata", mock_get_metadata):
+            # Call the method
+            result = await classic_handler.get_emails_metadata(
+                page=1,
+                page_size=10,
+                before=now,
+                since=None,
+                subject="Test",
+                from_address="sender@example.com",
+                to_address=None,
+            )
 
-        # Apply the mocks
-        with patch.object(classic_handler.incoming_client, "get_emails_metadata_stream", return_value=mock_stream):
-            with patch.object(classic_handler.incoming_client, "get_email_count", mock_count):
-                # Call the method
-                result = await classic_handler.get_emails_metadata(
-                    page=1,
-                    page_size=10,
-                    before=now,
-                    since=None,
-                    subject="Test",
-                    from_address="sender@example.com",
-                    to_address=None,
-                )
+            # Verify the result
+            assert isinstance(result, EmailMetadataPageResponse)
+            assert result.page == 1
+            assert result.page_size == 10
+            assert result.before == now
+            assert result.since is None
+            assert result.subject == "Test"
+            assert len(result.emails) == 1
+            assert isinstance(result.emails[0], EmailMetadata)
+            assert result.emails[0].subject == "Test Subject"
+            assert result.emails[0].sender == "sender@example.com"
+            assert result.emails[0].date == now
+            assert result.emails[0].attachments == []
+            assert result.total == 1
 
-                # Verify the result
-                assert isinstance(result, EmailMetadataPageResponse)
-                assert result.page == 1
-                assert result.page_size == 10
-                assert result.before == now
-                assert result.since is None
-                assert result.subject == "Test"
-                assert len(result.emails) == 1
-                assert isinstance(result.emails[0], EmailMetadata)
-                assert result.emails[0].subject == "Test Subject"
-                assert result.emails[0].sender == "sender@example.com"
-                assert result.emails[0].date == now
-                assert result.emails[0].attachments == []
-                assert result.total == 1
-
-                # Verify the client methods were called correctly
-                classic_handler.incoming_client.get_emails_metadata_stream.assert_called_once_with(
-                    1, 10, now, None, "Test", "sender@example.com", None, "desc", "INBOX", None, None, None
-                )
-                mock_count.assert_called_once_with(
-                    now,
-                    None,
-                    "Test",
-                    from_address="sender@example.com",
-                    to_address=None,
-                    mailbox="INBOX",
-                    seen=None,
-                    flagged=None,
-                    answered=None,
-                )
+            # Verify the client method was called correctly
+            mock_get_metadata.assert_called_once_with(
+                1, 10, now, None, "Test", "sender@example.com", None, "desc", "INBOX", None, None, None
+            )
 
     @pytest.mark.asyncio
     async def test_get_emails_with_mailbox(self, classic_handler):
@@ -135,36 +119,22 @@ class TestClassicEmailHandler:
             "attachments": [],
         }
 
-        mock_stream = AsyncMock()
-        mock_stream.__aiter__.return_value = [email_data]
-        mock_count = AsyncMock(return_value=1)
+        mock_get_metadata = AsyncMock(return_value=(1, [email_data]))
 
-        with patch.object(classic_handler.incoming_client, "get_emails_metadata_stream", return_value=mock_stream):
-            with patch.object(classic_handler.incoming_client, "get_email_count", mock_count):
-                result = await classic_handler.get_emails_metadata(
-                    page=1,
-                    page_size=10,
-                    mailbox="Sent",
-                )
+        with patch.object(classic_handler.incoming_client, "get_emails_metadata", mock_get_metadata):
+            result = await classic_handler.get_emails_metadata(
+                page=1,
+                page_size=10,
+                mailbox="Sent",
+            )
 
-                assert isinstance(result, EmailMetadataPageResponse)
-                assert len(result.emails) == 1
+            assert isinstance(result, EmailMetadataPageResponse)
+            assert len(result.emails) == 1
 
-                # Verify mailbox parameter was passed correctly
-                classic_handler.incoming_client.get_emails_metadata_stream.assert_called_once_with(
-                    1, 10, None, None, None, None, None, "desc", "Sent", None, None, None
-                )
-                mock_count.assert_called_once_with(
-                    None,
-                    None,
-                    None,
-                    from_address=None,
-                    to_address=None,
-                    mailbox="Sent",
-                    seen=None,
-                    flagged=None,
-                    answered=None,
-                )
+            # Verify mailbox parameter was passed correctly
+            mock_get_metadata.assert_called_once_with(
+                1, 10, None, None, None, None, None, "desc", "Sent", None, None, None
+            )
 
     @pytest.mark.asyncio
     async def test_send_email(self, classic_handler):

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -211,8 +211,8 @@ class TestEmailClient:
         assert criteria == ["SUBJECT", '"He said hello"']
 
     @pytest.mark.asyncio
-    async def test_get_emails_stream(self, email_client):
-        """Test getting emails stream returns sorted, paginated results."""
+    async def test_get_emails_metadata(self, email_client):
+        """Test getting emails metadata returns total and sorted, paginated results."""
         mock_imap = AsyncMock()
         mock_imap._client_task = asyncio.Future()
         mock_imap._client_task.set_result(None)
@@ -260,11 +260,10 @@ class TestEmailClient:
                 with patch.object(
                     email_client, "_batch_fetch_headers", return_value=mock_metadata
                 ) as mock_fetch_headers:
-                    emails = []
-                    async for email_data in email_client.get_emails_metadata_stream(page=1, page_size=10):
-                        emails.append(email_data)
+                    total, emails = await email_client.get_emails_metadata(page=1, page_size=10)
 
-                    # Behavior: returns emails sorted by date desc (newest first)
+                    # Behavior: returns total count and emails sorted by date desc (newest first)
+                    assert total == 3
                     assert len(emails) == 3
                     assert emails[0]["subject"] == "Subject 3"
                     assert emails[1]["subject"] == "Subject 2"
@@ -277,34 +276,6 @@ class TestEmailClient:
                     mock_fetch_dates.assert_called_once_with(mock_imap, [b"1", b"2", b"3"])
                     # Headers fetched for page UIDs in sorted order (desc by date)
                     mock_fetch_headers.assert_called_once_with(mock_imap, ["3", "2", "1"])
-
-    @pytest.mark.asyncio
-    async def test_get_email_count(self, email_client):
-        """Test getting email count."""
-        # Mock IMAP client
-        mock_imap = AsyncMock()
-        mock_imap._client_task = asyncio.Future()
-        mock_imap._client_task.set_result(None)
-        mock_imap.wait_hello_from_server = AsyncMock()
-        mock_imap.login = AsyncMock()
-        mock_imap.select = AsyncMock()
-        mock_imap.search = AsyncMock(return_value=(None, [b"1 2 3 4 5"]))
-        mock_imap.uid_search = AsyncMock(return_value=(None, [b"1 2 3 4 5"]))
-        mock_imap.logout = AsyncMock()
-
-        # Mock IMAP class
-        with patch.object(email_client, "imap_class", return_value=mock_imap):
-            count = await email_client.get_email_count()
-
-            assert count == 5
-
-            # Verify IMAP methods were called correctly
-            mock_imap.login.assert_called_once_with(
-                email_client.email_server.user_name, email_client.email_server.password.get_secret_value()
-            )
-            mock_imap.select.assert_called_once_with('"INBOX"')
-            mock_imap.uid_search.assert_called_once_with("ALL")
-            mock_imap.logout.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_send_email(self, email_client):


### PR DESCRIPTION
## Summary
- Removed `EmailClient.get_email_count()` which opened a separate IMAP connection just to count matching emails
- Changed `get_emails_metadata_stream` from an `AsyncGenerator` to a regular async method returning `tuple[int, list[dict]]` (total + page emails), renamed to `get_emails_metadata`
- The stream already searches all matching UIDs — the total is `len(email_ids)`, no second connection needed
- The generator was always fully consumed by its only caller into a list, so the streaming interface wasn't serving any purpose

## Motivation
- **Eliminates redundant IMAP connection** — every `list_emails_metadata` call was opening two IMAP sessions: one for fetching metadata, another just to count. This halves the connection overhead.
- **Fixes potential count/data mismatch** — the two independent sessions could disagree if emails arrived or were deleted between calls.
- **Removes dead code** — `get_email_count` wasn't in the abstract `EmailHandler` base class and had no other callers.

## Changes
- `mcp_email_server/emails/classic.py`: Delete `get_email_count`, rename `get_emails_metadata_stream` → `get_emails_metadata`, return `(total, page_emails)` tuple, remove `AsyncGenerator` import
- `tests/test_email_client.py`: Delete `test_get_email_count`, update stream test for new return type
- `tests/test_classic_handler.py`: Remove `get_email_count` mocking, simplify handler tests

Net: -115 lines (66 added, 181 removed)

## Test plan
- [x] All 132 existing tests pass
- [x] `test_get_emails_metadata` verifies total count is returned alongside page results
- [x] Handler tests verify `get_emails_metadata` is called (not `get_email_count`)