### PR TITLE
feat: Add create_folder and list_folders tools

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -197,6 +197,28 @@ async def delete_emails(
 
 
 @mcp.tool(
+    description="Create an IMAP folder/mailbox. Supports hierarchical folder names (e.g. 'Projects/Active') and automatically creates parent folders if needed."
+)
+async def create_folder(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    folder_name: Annotated[
+        str,
+        Field(description="The name of the folder to create (e.g. 'Archive', 'Projects/Active')."),
+    ],
+) -> str:
+    handler = dispatch_handler(account_name)
+    return await handler.create_folder(folder_name)
+
+
+@mcp.tool(description="List all IMAP folders/mailboxes for an email account.")
+async def list_folders(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+) -> list[str]:
+    handler = dispatch_handler(account_name)
+    return await handler.list_folders()
+
+
+@mcp.tool(
     description="Download an email attachment and save it to the specified path. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
 )
 async def download_attachment(

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -105,3 +105,25 @@ class EmailHandler(abc.ABC):
         Returns:
             AttachmentDownloadResponse with download result information.
         """
+
+    @abc.abstractmethod
+    async def create_folder(self, folder_name: str) -> str:
+        """
+        Create an IMAP folder/mailbox. Creates parent folders if needed
+        for hierarchical names (e.g. "Parent/Child").
+
+        Args:
+            folder_name: The name of the folder to create.
+
+        Returns:
+            A status message indicating success.
+        """
+
+    @abc.abstractmethod
+    async def list_folders(self) -> list[str]:
+        """
+        List all IMAP folders/mailboxes for the account.
+
+        Returns:
+            A list of folder names.
+        """

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -982,6 +982,83 @@ class EmailClient:
 
         return deleted_ids, failed_ids
 
+    async def create_folder(self, folder_name: str) -> str:
+        """Create an IMAP folder. Creates parent folders if needed for hierarchical names."""
+        imap = self._imap_connect()
+
+        try:
+            await imap._client_task
+            await imap.wait_hello_from_server()
+            await imap.login(self.email_server.user_name, self.email_server.password)
+            await _send_imap_id(imap)
+
+            # Determine the hierarchy delimiter by listing the root
+            _, list_data = await imap.list('""', '""')
+            delimiter = "/"
+            for item in list_data:
+                item_str = item.decode("utf-8") if isinstance(item, bytes) else str(item)
+                # Parse delimiter from LIST response: (flags) "delimiter" "name"
+                parts = item_str.split('"')
+                if len(parts) >= 2:
+                    delimiter = parts[1]
+                    break
+
+            # Split folder name on the delimiter and create parent folders first
+            folder_parts = folder_name.split(delimiter)
+            created = []
+            for i in range(1, len(folder_parts) + 1):
+                partial = delimiter.join(folder_parts[:i])
+                result = await imap.create(_quote_mailbox(partial))
+                status = result[0] if isinstance(result, tuple) else result
+                if str(status).upper() == "OK":
+                    # Subscribe so the folder is visible in email clients
+                    await imap.subscribe(_quote_mailbox(partial))
+                    created.append(partial)
+                    logger.info(f"Created and subscribed folder: '{partial}'")
+                else:
+                    # Folder may already exist — that's fine for parent folders
+                    logger.debug(f"Create folder '{partial}' returned: {status}")
+
+            if not created:
+                return f"Folder '{folder_name}' already exists"
+            if len(created) == 1:
+                return f"Created folder '{folder_name}'"
+            return f"Created folders: {', '.join(created)}"
+
+        finally:
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
+    async def list_folders(self) -> list[str]:
+        """List all IMAP folders/mailboxes."""
+        imap = self._imap_connect()
+
+        try:
+            await imap._client_task
+            await imap.wait_hello_from_server()
+            await imap.login(self.email_server.user_name, self.email_server.password)
+            await _send_imap_id(imap)
+
+            _, folders_data = await imap.list('""', "*")
+            folders = []
+            for item in folders_data:
+                item_str = item.decode("utf-8") if isinstance(item, bytes) else str(item)
+                # IMAP LIST response format: (flags) "delimiter" "name"
+                parts = item_str.split('"')
+                if len(parts) >= 3:
+                    folder_name = parts[-2]
+                    folders.append(folder_name)
+
+            return sorted(folders)
+
+        finally:
+            try:
+                await imap.logout()
+            except Exception as e:
+                logger.info(f"Error during logout: {e}")
+
 
 class ClassicEmailHandler(EmailHandler):
     def __init__(self, email_settings: EmailSettings):
@@ -1110,6 +1187,14 @@ class ClassicEmailHandler(EmailHandler):
     async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """Delete emails by their UIDs. Returns (deleted_ids, failed_ids)."""
         return await self.incoming_client.delete_emails(email_ids, mailbox)
+
+    async def create_folder(self, folder_name: str) -> str:
+        """Create an IMAP folder/mailbox."""
+        return await self.incoming_client.create_folder(folder_name)
+
+    async def list_folders(self) -> list[str]:
+        """List all IMAP folders/mailboxes."""
+        return await self.incoming_client.list_folders()
 
     async def download_attachment(
         self,

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -721,3 +721,111 @@ class TestBatchFetchHeaders:
         assert len(result) == 2
         assert result["100"]["subject"] == "First"
         assert result["200"]["subject"] == "Second"
+
+
+class TestCreateFolder:
+    @pytest.mark.asyncio
+    async def test_create_folder_simple(self, email_client):
+        """Test creating a simple (non-hierarchical) folder."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\HasNoChildren) "/" "INBOX"']))
+        mock_imap.create = AsyncMock(return_value=("OK", [b"CREATE completed"]))
+        mock_imap.subscribe = AsyncMock(return_value=("OK", [b"SUBSCRIBE completed"]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.create_folder("Archive")
+
+        assert "Archive" in result
+        mock_imap.create.assert_called_once_with('"Archive"')
+        mock_imap.subscribe.assert_called_once_with('"Archive"')
+        mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_folder_hierarchical(self, email_client):
+        """Test creating a hierarchical folder creates parent folders first."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\HasNoChildren) "/" "INBOX"']))
+        mock_imap.create = AsyncMock(return_value=("OK", [b"CREATE completed"]))
+        mock_imap.subscribe = AsyncMock(return_value=("OK", [b"SUBSCRIBE completed"]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            await email_client.create_folder("02 areas/VEA bestuur")
+
+        assert mock_imap.create.call_count == 2
+        mock_imap.create.assert_any_call('"02 areas"')
+        mock_imap.create.assert_any_call('"02 areas/VEA bestuur"')
+        assert mock_imap.subscribe.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_create_folder_already_exists(self, email_client):
+        """Test creating a folder that already exists returns appropriate message."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\HasNoChildren) "/" "INBOX"']))
+        mock_imap.create = AsyncMock(return_value=("NO", [b"Mailbox already exists"]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.create_folder("INBOX")
+
+        assert "already exists" in result
+
+
+class TestListFolders:
+    @pytest.mark.asyncio
+    async def test_list_folders(self, email_client):
+        """Test listing all IMAP folders."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(
+            return_value=(
+                "OK",
+                [
+                    b'(\\HasNoChildren) "/" "INBOX"',
+                    b'(\\HasNoChildren) "/" "Archive"',
+                    b'(\\HasNoChildren \\Sent) "/" "Sent"',
+                    b'(\\HasChildren) "/" "Projects"',
+                    b'(\\HasNoChildren) "/" "Projects/Active"',
+                ],
+            )
+        )
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            folders = await email_client.list_folders()
+
+        assert folders == ["Archive", "INBOX", "Projects", "Projects/Active", "Sent"]
+        mock_imap.login.assert_called_once()
+        mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_folders_empty(self, email_client):
+        """Test listing folders when server returns empty list."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock()
+        mock_imap.list = AsyncMock(return_value=("OK", []))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            folders = await email_client.list_folders()
+
+        assert folders == []


### PR DESCRIPTION
## Summary
- Adds `create_folder` tool for creating IMAP folders/mailboxes, with support for hierarchical folder names (e.g. `Projects/Active` auto-creates `Projects` first) and automatic subscription so folders are visible in email clients
- Adds `list_folders` tool for listing all IMAP folders/mailboxes on an account
- Includes full test coverage (5 tests) following existing patterns

## Implementation
- Abstract methods added to `EmailHandler` interface (`__init__.py`)
- IMAP implementation in `EmailClient` (`classic.py`) using `_quote_mailbox()` for proper quoting, hierarchy delimiter detection via IMAP LIST, and `create` + `subscribe` calls
- Delegation in `ClassicEmailHandler` following existing patterns (`delete_emails`, etc.)
- Tool registration in `app.py` with proper `Annotated`/`Field` parameter descriptions

## Test plan
- [x] `TestCreateFolder::test_create_folder_simple` — single folder creation + subscribe
- [x] `TestCreateFolder::test_create_folder_hierarchical` — parent folders created first
- [x] `TestCreateFolder::test_create_folder_already_exists` — graceful handling
- [x] `TestListFolders::test_list_folders` — parses LIST response, returns sorted names
- [x] `TestListFolders::test_list_folders_empty` — handles empty response

🤖 Generated with [Claude Code](https://claude.com/claude-code)