### PR TITLE
fix: reduce batch fetch chunk size to avoid RecursionError in aioimaplib

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -352,7 +352,7 @@ class EmailClient:
         self,
         imap: aioimaplib.IMAP4_SSL | aioimaplib.IMAP4,
         email_ids: list[bytes],
-        chunk_size: int = 5000,
+        chunk_size: int = 500,
     ) -> dict[str, datetime]:
         """Batch fetch INTERNALDATE for all UIDs in parallel chunks."""
         if not email_ids:


### PR DESCRIPTION
aioimaplib's _handle_responses uses recursion to process IMAP response lines. With chunk_size=5000, a mailbox with thousands of emails causes the response to exceed Python's default recursion limit (1000), leading to a fatal RecursionError on the SSL protocol.

Reduce chunk_size from 5000 to 500 to keep response line count well within the recursion limit.