### PR TITLE
fix(cli): allow HTTP transport host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                   | `true`        | No       |
 | `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)       | -             | No       |
 
+### HTTP Transport Security
+
+HTTP transports (`sse` and `streamable-http`) validate request `Host` and `Origin` headers to protect against DNS rebinding attacks. Localhost is allowed by default. For Docker networks or reverse proxies, configure the expected service names explicitly.
+
+| Variable                              | Description                                                      | Default           |
+| ------------------------------------- | ---------------------------------------------------------------- | ----------------- |
+| `MCP_HOST`                            | HTTP bind host for `streamable-http`                             | `localhost`       |
+| `MCP_PORT`                            | HTTP bind port for `streamable-http`                             | `9557`            |
+| `MCP_ALLOWED_HOSTS`                   | Comma-separated allowed `Host` values. Supports `host:*` ports   | Localhost hosts   |
+| `MCP_ALLOWED_ORIGINS`                 | Comma-separated allowed `Origin` values. Supports `host:*` ports | Localhost origins |
+| `MCP_ENABLE_DNS_REBINDING_PROTECTION` | Enable DNS rebinding protection                                  | `true`            |
+
+Docker Compose example:
+
+```yaml
+services:
+  mcp-email-server:
+    image: ghcr.io/ai-zerolab/mcp-email-server:latest
+    command: ["streamable-http"]
+    environment:
+      MCP_HOST: 0.0.0.0
+      MCP_PORT: 9557
+      MCP_ALLOWED_HOSTS: mcp-email-server:*,localhost:*,127.0.0.1:*
+      MCP_ALLOWED_ORIGINS: http://mcp-email-server:*,http://localhost:*,http://127.0.0.1:*
+```
+
+Bare host entries such as `MCP_ALLOWED_HOSTS=mcp-email-server` also allow any port on that host. `MCP_ENABLE_DNS_REBINDING_PROTECTION=false`, `MCP_ALLOWED_HOSTS=*`, or `MCP_ALLOWED_ORIGINS=*` disables Host and Origin validation entirely. Use those options only in isolated local development environments.
+
+IPv6 literals in allowlists should use bracketed notation, such as `[::1]:*` and `http://[::1]:*`.
+
 ### Enabling Attachment Downloads
 
 By default, downloading email attachments is disabled for security reasons. To enable this feature, you can either:

--- a/mcp_email_server/cli.py
+++ b/mcp_email_server/cli.py
@@ -1,11 +1,116 @@
 import os
 
 import typer
+from mcp.server.transport_security import TransportSecuritySettings
 
 from mcp_email_server.app import mcp
 from mcp_email_server.config import delete_settings
 
 app = typer.Typer()
+
+LOOPBACK_ALLOWED_HOSTS = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+LOOPBACK_ALLOWED_ORIGINS = ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
+WILDCARD_IPV4_BIND_HOST = "0.0.0.0"  # noqa: S104
+WILDCARD_BIND_HOSTS = {WILDCARD_IPV4_BIND_HOST, "::", ""}
+FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _split_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _is_dns_rebinding_protection_enabled() -> bool:
+    value = os.environ.get("MCP_ENABLE_DNS_REBINDING_PROTECTION")
+    if value is None:
+        return True
+    return value.strip().lower() not in FALSE_VALUES
+
+
+def _normalize_host(host: str) -> str:
+    if host == "::1":
+        return "[::1]"
+    return host
+
+
+def _unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _expand_allowed_hosts(allowed_hosts: list[str]) -> list[str]:
+    expanded: list[str] = []
+    for allowed_host in allowed_hosts:
+        expanded.append(allowed_host)
+        if (":" not in allowed_host and allowed_host != "*") or (
+            allowed_host.startswith("[") and allowed_host.endswith("]")
+        ):
+            expanded.append(f"{allowed_host}:*")
+    return _unique(expanded)
+
+
+def _expand_allowed_origins(allowed_origins: list[str]) -> list[str]:
+    expanded: list[str] = []
+    for allowed_origin in allowed_origins:
+        expanded.append(allowed_origin)
+        scheme_separator = "://"
+        if scheme_separator in allowed_origin and allowed_origin != "*":
+            scheme, host = allowed_origin.split(scheme_separator, maxsplit=1)
+            has_port = host.rsplit(":", maxsplit=1)[-1].isdigit() or host.endswith(":*")
+            if (":" not in host or (host.startswith("[") and host.endswith("]"))) and not has_port:
+                expanded.append(f"{scheme}{scheme_separator}{host}:*")
+    return _unique(expanded)
+
+
+def _default_allowed_hosts(host: str, port: int) -> list[str]:
+    allowed_hosts = list(LOOPBACK_ALLOWED_HOSTS)
+    normalized_host = _normalize_host(host)
+
+    if normalized_host in {"127.0.0.1", "localhost", "[::1]"} or host in WILDCARD_BIND_HOSTS:
+        return allowed_hosts
+
+    allowed_hosts.extend([normalized_host, f"{normalized_host}:{port}", f"{normalized_host}:*"])
+    return allowed_hosts
+
+
+def _default_allowed_origins(host: str, port: int) -> list[str]:
+    allowed_origins = list(LOOPBACK_ALLOWED_ORIGINS)
+    normalized_host = _normalize_host(host)
+
+    if normalized_host in {"127.0.0.1", "localhost", "[::1]"} or host in WILDCARD_BIND_HOSTS:
+        return allowed_origins
+
+    allowed_origins.extend([
+        f"http://{normalized_host}",
+        f"http://{normalized_host}:{port}",
+        f"http://{normalized_host}:*",
+        f"https://{normalized_host}",
+        f"https://{normalized_host}:{port}",
+        f"https://{normalized_host}:*",
+    ])
+    return allowed_origins
+
+
+def _build_transport_security_settings(host: str, port: int) -> TransportSecuritySettings:
+    allowed_hosts = _split_csv(os.environ.get("MCP_ALLOWED_HOSTS"))
+    allowed_origins = _split_csv(os.environ.get("MCP_ALLOWED_ORIGINS"))
+
+    if not _is_dns_rebinding_protection_enabled() or "*" in allowed_hosts or "*" in allowed_origins:
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=_expand_allowed_hosts(allowed_hosts) if allowed_hosts else _default_allowed_hosts(host, port),
+        allowed_origins=_expand_allowed_origins(allowed_origins)
+        if allowed_origins
+        else _default_allowed_origins(host, port),
+    )
+
+
+def _configure_http_transport(host: str, port: int) -> None:
+    mcp.settings.host = host
+    mcp.settings.port = port
+    mcp.settings.transport_security = _build_transport_security_settings(host, port)
 
 
 @app.command()
@@ -18,18 +123,16 @@ def sse(
     host: str = "localhost",
     port: int = 9557,
 ):
-    mcp.settings.host = host
-    mcp.settings.port = port
+    _configure_http_transport(host, port)
     mcp.run(transport="sse")
 
 
 @app.command()
 def streamable_http(
     host: str = os.environ.get("MCP_HOST", "localhost"),
-    port: int = os.environ.get("MCP_PORT", 9557),
+    port: int = int(os.environ.get("MCP_PORT", 9557)),
 ):
-    mcp.settings.host = host
-    mcp.settings.port = port
+    _configure_http_transport(host, port)
     mcp.run(transport="streamable-http")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,132 @@
+import pytest
+
+from mcp_email_server.app import mcp
+from mcp_email_server.cli import (
+    WILDCARD_IPV4_BIND_HOST,
+    _build_transport_security_settings,
+    _configure_http_transport,
+    _expand_allowed_hosts,
+    _expand_allowed_origins,
+    _split_csv,
+)
+
+
+def test_split_csv_trims_empty_items():
+    assert _split_csv(" localhost:*, mcp-email-server:* ,, ") == ["localhost:*", "mcp-email-server:*"]
+
+
+def test_expand_allowed_hosts_adds_wildcard_port_for_bare_host():
+    assert _expand_allowed_hosts(["mcp-email-server", "localhost:*", "[::1]"]) == [
+        "mcp-email-server",
+        "mcp-email-server:*",
+        "localhost:*",
+        "[::1]",
+        "[::1]:*",
+    ]
+
+
+def test_expand_allowed_origins_adds_wildcard_port_for_bare_origin():
+    assert _expand_allowed_origins(["http://mcp-email-server", "http://localhost:*"]) == [
+        "http://mcp-email-server",
+        "http://mcp-email-server:*",
+        "http://localhost:*",
+    ]
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "no", "off", " OFF "])
+def test_transport_security_can_be_disabled_with_false_values(monkeypatch, value):
+    monkeypatch.setenv("MCP_ENABLE_DNS_REBINDING_PROTECTION", value)
+
+    settings = _build_transport_security_settings(WILDCARD_IPV4_BIND_HOST, 9557)
+
+    assert settings.enable_dns_rebinding_protection is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "unexpected", ""])
+def test_transport_security_stays_enabled_with_non_false_values(monkeypatch, value):
+    monkeypatch.setenv("MCP_ENABLE_DNS_REBINDING_PROTECTION", value)
+
+    settings = _build_transport_security_settings(WILDCARD_IPV4_BIND_HOST, 9557)
+
+    assert settings.enable_dns_rebinding_protection is True
+
+
+def test_transport_security_uses_explicit_allowed_hosts(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "mcp-email-server,localhost:*")
+    monkeypatch.setenv("MCP_ALLOWED_ORIGINS", "http://mcp-email-server,http://localhost:*")
+
+    settings = _build_transport_security_settings(WILDCARD_IPV4_BIND_HOST, 9557)
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert settings.allowed_hosts == ["mcp-email-server", "mcp-email-server:*", "localhost:*"]
+    assert settings.allowed_origins == [
+        "http://mcp-email-server",
+        "http://mcp-email-server:*",
+        "http://localhost:*",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("MCP_ALLOWED_HOSTS", "*"),
+        ("MCP_ALLOWED_ORIGINS", "*"),
+    ],
+)
+def test_transport_security_wildcard_allowlist_disables_protection(monkeypatch, env_name, env_value):
+    monkeypatch.setenv(env_name, env_value)
+
+    settings = _build_transport_security_settings(WILDCARD_IPV4_BIND_HOST, 9557)
+
+    assert settings.enable_dns_rebinding_protection is False
+
+
+@pytest.mark.parametrize("host", [WILDCARD_IPV4_BIND_HOST, "::", ""])
+def test_transport_security_defaults_to_loopback_for_wildcard_bind(monkeypatch, host):
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("MCP_ALLOWED_ORIGINS", raising=False)
+
+    settings = _build_transport_security_settings(host, 9557)
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert settings.allowed_hosts == ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+    assert settings.allowed_origins == [
+        "http://127.0.0.1:*",
+        "http://localhost:*",
+        "http://[::1]:*",
+    ]
+
+
+def test_transport_security_defaults_include_named_host(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("MCP_ALLOWED_ORIGINS", raising=False)
+
+    settings = _build_transport_security_settings("mcp-email-server", 9557)
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert "mcp-email-server" in settings.allowed_hosts
+    assert "mcp-email-server:9557" in settings.allowed_hosts
+    assert "mcp-email-server:*" in settings.allowed_hosts
+    assert "http://mcp-email-server:9557" in settings.allowed_origins
+    assert "http://mcp-email-server:*" in settings.allowed_origins
+
+
+def test_configure_http_transport_updates_mcp_settings(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "mcp-email-server:*")
+    monkeypatch.setenv("MCP_ALLOWED_ORIGINS", "http://mcp-email-server:*")
+
+    original_host = mcp.settings.host
+    original_port = mcp.settings.port
+    original_transport_security = mcp.settings.transport_security
+
+    try:
+        _configure_http_transport(WILDCARD_IPV4_BIND_HOST, 9557)
+
+        assert mcp.settings.host == WILDCARD_IPV4_BIND_HOST
+        assert mcp.settings.port == 9557
+        assert mcp.settings.transport_security.allowed_hosts == ["mcp-email-server:*"]
+        assert mcp.settings.transport_security.allowed_origins == ["http://mcp-email-server:*"]
+    finally:
+        mcp.settings.host = original_host
+        mcp.settings.port = original_port
+        mcp.settings.transport_security = original_transport_security


### PR DESCRIPTION
Support MCP_ALLOWED_HOSTS and MCP_ALLOWED_ORIGINS for SSE and streamable HTTP transports so Docker service names can pass Host and Origin validation.

Add explicit development opt-outs for DNS rebinding protection and document Docker usage.

Assisted-by: YAAI <261597362+yaai-bot@users.noreply.github.com>