### PR TITLE
feat: add IMAP STARTTLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                       | -             | Yes      |
 | `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                       | `993`         | No       |
 | `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                        | `true`        | No       |
+| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                   | `false`       | No       |
 | `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed) | `true`        | No       |
 | `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host                                       | -             | Yes      |
 | `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                       | `465`         | No       |
@@ -182,9 +183,9 @@ sent_folder_name = "INBOX.Sent"
 
 **To disable saving to Sent folder**, set `MCP_EMAIL_SERVER_SAVE_TO_SENT=false` or `save_to_sent = false` in your TOML config.
 
-### Self-Signed Certificates (e.g., ProtonMail Bridge)
+### Self-Signed Certificates and IMAP STARTTLS (e.g., ProtonMail Bridge)
 
-If you're using a local mail server with self-signed certificates (like ProtonMail Bridge), you'll need to disable SSL certificate verification:
+Local mail bridges such as ProtonMail Bridge commonly use STARTTLS with self-signed certificates. Configure IMAP with plaintext connect plus STARTTLS upgrade, and disable certificate verification for the local bridge certificate:
 
 ```json
 {
@@ -193,6 +194,10 @@ If you're using a local mail server with self-signed certificates (like ProtonMa
       "command": "uvx",
       "args": ["mcp-email-server@latest", "stdio"],
       "env": {
+        "MCP_EMAIL_SERVER_IMAP_HOST": "127.0.0.1",
+        "MCP_EMAIL_SERVER_IMAP_PORT": "1143",
+        "MCP_EMAIL_SERVER_IMAP_SSL": "false",
+        "MCP_EMAIL_SERVER_IMAP_START_SSL": "true",
         "MCP_EMAIL_SERVER_IMAP_VERIFY_SSL": "false",
         "MCP_EMAIL_SERVER_SMTP_VERIFY_SSL": "false"
       }
@@ -209,6 +214,10 @@ account_name = "protonmail"
 # ... other settings ...
 
 [emails.incoming]
+host = "127.0.0.1"
+port = 1143
+use_ssl = false
+start_ssl = true
 verify_ssl = false
 
 [emails.outgoing]

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -106,6 +106,7 @@ class EmailSettings(AccountAttributes):
         imap_password: str | None = None,
         imap_port: int = 993,
         imap_ssl: bool = True,
+        imap_start_ssl: bool = False,
         imap_verify_ssl: bool = True,
         smtp_port: int = 465,
         smtp_ssl: bool = True,
@@ -126,6 +127,7 @@ class EmailSettings(AccountAttributes):
                 host=imap_host,
                 port=imap_port,
                 use_ssl=imap_ssl,
+                start_ssl=imap_start_ssl,
                 verify_ssl=imap_verify_ssl,
             ),
             outgoing=EmailServer(
@@ -154,6 +156,7 @@ class EmailSettings(AccountAttributes):
         - MCP_EMAIL_SERVER_IMAP_HOST
         - MCP_EMAIL_SERVER_IMAP_PORT (default: 993)
         - MCP_EMAIL_SERVER_IMAP_SSL (default: true)
+        - MCP_EMAIL_SERVER_IMAP_START_SSL (default: false)
         - MCP_EMAIL_SERVER_IMAP_VERIFY_SSL (default: true)
         - MCP_EMAIL_SERVER_SMTP_HOST
         - MCP_EMAIL_SERVER_SMTP_PORT (default: 465)
@@ -192,6 +195,7 @@ class EmailSettings(AccountAttributes):
                 imap_host=imap_host,
                 imap_port=int(os.getenv("MCP_EMAIL_SERVER_IMAP_PORT", "993")),
                 imap_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_SSL"), True),
+                imap_start_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_START_SSL"), False),
                 imap_verify_ssl=_parse_bool_env(os.getenv("MCP_EMAIL_SERVER_IMAP_VERIFY_SSL"), True),
                 smtp_host=smtp_host,
                 smtp_port=int(os.getenv("MCP_EMAIL_SERVER_SMTP_PORT", "465")),

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -160,6 +160,52 @@ def _create_ssl_context(verify_ssl: bool) -> ssl.SSLContext | None:
     return ctx
 
 
+def _create_starttls_ssl_context(verify_ssl: bool) -> ssl.SSLContext:
+    """Create a concrete SSL context for asyncio STARTTLS upgrades."""
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    if not verify_ssl:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def _imap_capabilities(imap: aioimaplib.IMAP4) -> set[str]:
+    """Return normalized capabilities from an aioimaplib protocol."""
+    return {
+        capability.decode("utf-8", errors="replace").upper()
+        if isinstance(capability, bytes)
+        else str(capability).upper()
+        for capability in getattr(imap.protocol, "capabilities", ())
+    }
+
+
+async def _imap_starttls(imap: aioimaplib.IMAP4, ssl_context: ssl.SSLContext, host: str) -> None:
+    """Upgrade an IMAP connection to TLS via STARTTLS."""
+    capabilities = _imap_capabilities(imap)
+    if "STARTTLS" not in capabilities:
+        await imap.protocol.capability()
+        capabilities = _imap_capabilities(imap)
+    if "STARTTLS" not in capabilities:
+        raise OSError("IMAP server does not advertise STARTTLS capability")
+
+    response = await imap.protocol.execute(
+        aioimaplib.Command("STARTTLS", imap.protocol.new_tag(), loop=imap.protocol.loop)
+    )
+    status = _imap_status(response)
+    if status != "OK":
+        raise OSError(f"STARTTLS command failed: {status}")
+
+    loop = asyncio.get_running_loop()
+    tls_transport = await loop.start_tls(
+        imap.protocol.transport,
+        imap.protocol,
+        ssl_context,
+        server_hostname=host,
+    )
+    imap.protocol.transport = tls_transport
+    await imap.protocol.capability()
+
+
 # Backwards-compatible alias
 _create_smtp_ssl_context = _create_ssl_context
 
@@ -181,6 +227,37 @@ class EmailClient:
             imap_ssl_context = _create_ssl_context(self.email_server.verify_ssl)
             return self.imap_class(self.email_server.host, self.email_server.port, ssl_context=imap_ssl_context)
         return self.imap_class(self.email_server.host, self.email_server.port)
+
+    async def _connect_imap(self) -> aioimaplib.IMAP4_SSL | aioimaplib.IMAP4:
+        """Create, greet, and optionally STARTTLS-upgrade an IMAP connection."""
+        imap = self._imap_connect()
+        return await self._prepare_imap_connection(imap, self.email_server)
+
+    @staticmethod
+    async def _prepare_imap_connection(
+        imap: aioimaplib.IMAP4_SSL | aioimaplib.IMAP4,
+        server: EmailServer,
+    ) -> aioimaplib.IMAP4_SSL | aioimaplib.IMAP4:
+        """Wait for greeting and optionally STARTTLS-upgrade an IMAP connection."""
+        await imap._client_task
+        await imap.wait_hello_from_server()
+
+        if server.start_ssl:
+            ssl_context = _create_starttls_ssl_context(server.verify_ssl)
+            await _imap_starttls(imap, ssl_context, server.host)
+
+        return imap
+
+    @staticmethod
+    async def _connect_imap_server(server: EmailServer) -> aioimaplib.IMAP4_SSL | aioimaplib.IMAP4:
+        """Create, greet, and optionally STARTTLS-upgrade an IMAP connection."""
+        if server.use_ssl:
+            imap_ssl_context = _create_ssl_context(server.verify_ssl)
+            imap = aioimaplib.IMAP4_SSL(server.host, server.port, ssl_context=imap_ssl_context)
+        else:
+            imap = aioimaplib.IMAP4(server.host, server.port)
+
+        return await EmailClient._prepare_imap_connection(imap, server)
 
     def _get_smtp_ssl_context(self) -> ssl.SSLContext | None:
         """Get SSL context for SMTP connections based on verify_ssl setting."""
@@ -537,12 +614,8 @@ class EmailClient:
         flagged: bool | None = None,
         answered: bool | None = None,
     ) -> tuple[int, list[dict[str, Any]]]:
-        imap = self._imap_connect()
+        imap = await self._connect_imap()
         try:
-            # Wait for the connection to be established
-            await imap._client_task
-            await imap.wait_hello_from_server()
-
             # Login and select mailbox
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
@@ -654,12 +727,8 @@ class EmailClient:
     async def get_email_body_by_id(
         self, email_id: str, mailbox: str = "INBOX", mark_as_read: bool = False
     ) -> dict[str, Any] | None:
-        imap = self._imap_connect()
+        imap = await self._connect_imap()
         try:
-            # Wait for the connection to be established
-            await imap._client_task
-            await imap.wait_hello_from_server()
-
             # Login and select mailbox
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
@@ -719,11 +788,8 @@ class EmailClient:
         Returns:
             A dictionary with download result information.
         """
-        imap = self._imap_connect()
+        imap = await self._connect_imap()
         try:
-            await imap._client_task
-            await imap.wait_hello_from_server()
-
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
             await imap.select(_quote_mailbox(mailbox))
@@ -983,11 +1049,7 @@ class EmailClient:
         Returns:
             True if successfully saved, False otherwise
         """
-        if incoming_server.use_ssl:
-            imap_ssl_context = _create_ssl_context(incoming_server.verify_ssl)
-            imap = aioimaplib.IMAP4_SSL(incoming_server.host, incoming_server.port, ssl_context=imap_ssl_context)
-        else:
-            imap = aioimaplib.IMAP4(incoming_server.host, incoming_server.port)
+        imap = await self._connect_imap_server(incoming_server)
 
         # Common Sent folder names across different providers
         sent_folder_candidates = [
@@ -1003,8 +1065,6 @@ class EmailClient:
         sent_folder_candidates = [f for f in sent_folder_candidates if f]
 
         try:
-            await imap._client_task
-            await imap.wait_hello_from_server()
             await _imap_login(imap, incoming_server.user_name, incoming_server.password.get_secret_value())
             await _send_imap_id(imap)
 
@@ -1075,15 +1135,9 @@ class EmailClient:
         (if the server supports APPENDUID / RFC 4315), or ``"unknown"`` on
         success without UID, or ``None`` on failure.
         """
-        if incoming_server.use_ssl:
-            imap_ssl_context = _create_ssl_context(incoming_server.verify_ssl)
-            imap = aioimaplib.IMAP4_SSL(incoming_server.host, incoming_server.port, ssl_context=imap_ssl_context)
-        else:
-            imap = aioimaplib.IMAP4(incoming_server.host, incoming_server.port)
+        imap = await self._connect_imap_server(incoming_server)
 
         try:
-            await imap._client_task
-            await imap.wait_hello_from_server()
             await _imap_login(imap, incoming_server.user_name, incoming_server.password.get_secret_value())
             await _send_imap_id(imap)
 
@@ -1129,13 +1183,11 @@ class EmailClient:
 
     async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """Delete emails by their UIDs. Returns (deleted_ids, failed_ids)."""
-        imap = self._imap_connect()
+        imap = await self._connect_imap()
         deleted_ids = []
         failed_ids = []
 
         try:
-            await imap._client_task
-            await imap.wait_hello_from_server()
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
             await imap.select(_quote_mailbox(mailbox))
@@ -1159,13 +1211,11 @@ class EmailClient:
 
     async def mark_emails_as_read(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """Mark emails as read by setting the \\Seen flag. Returns (marked_ids, failed_ids)."""
-        imap = self._imap_connect()
+        imap = await self._connect_imap()
         marked_ids: list[str] = []
         failed_ids: list[str] = []
 
         try:
-            await imap._client_task
-            await imap.wait_hello_from_server()
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
             select_response = await imap.select(_quote_mailbox(mailbox))
@@ -1191,13 +1241,11 @@ class EmailClient:
         self, email_ids: list[str], source_mailbox: str, destination_mailbox: str
     ) -> tuple[list[str], list[str]]:
         """Move emails to a different mailbox. Uses IMAP MOVE (RFC 6851) with COPY+DELETE fallback."""
-        imap = self._imap_connect()
+        imap = await self._connect_imap()
         moved_ids = []
         failed_ids = []
 
         try:
-            await imap._client_task
-            await imap.wait_hello_from_server()
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
             select_response = await imap.select(_quote_mailbox(source_mailbox))
@@ -1239,12 +1287,10 @@ class EmailClient:
 
     async def list_mailboxes(self, pattern: str = "*", reference: str = "") -> list[MailboxInfo]:
         """List available IMAP mailboxes with flags and delimiter."""
-        imap = self._imap_connect()
+        imap = await self._connect_imap()
         mailboxes = []
 
         try:
-            await imap._client_task
-            await imap.wait_hello_from_server()
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
 

--- a/tests/test_imap_starttls.py
+++ b/tests/test_imap_starttls.py
@@ -1,0 +1,200 @@
+import asyncio
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_email_server.config import EmailServer, EmailSettings
+from mcp_email_server.emails.classic import EmailClient, _create_starttls_ssl_context, _imap_starttls
+
+
+class Response:
+    def __init__(self, result: str, lines: list[bytes] | None = None):
+        self.result = result
+        self.lines = lines or []
+
+
+def _make_imap(capabilities=("IMAP4rev1", "STARTTLS")):
+    imap = AsyncMock()
+    imap._client_task = asyncio.Future()
+    imap._client_task.set_result(None)
+    imap.wait_hello_from_server = AsyncMock()
+    imap.protocol = MagicMock()
+    imap.protocol.capabilities = set(capabilities)
+    imap.protocol.loop = asyncio.get_event_loop()
+    imap.protocol.new_tag.return_value = "A001"
+    imap.protocol.execute = AsyncMock(return_value=Response("OK"))
+    imap.protocol.capability = AsyncMock()
+    imap.protocol.transport = MagicMock()
+    return imap
+
+
+def test_email_settings_init_accepts_imap_start_ssl():
+    settings = EmailSettings.init(
+        account_name="test",
+        full_name="Test User",
+        email_address="test@example.com",
+        user_name="test@example.com",
+        password="secret",
+        imap_host="127.0.0.1",
+        imap_port=1143,
+        imap_ssl=False,
+        imap_start_ssl=True,
+        smtp_host="127.0.0.1",
+    )
+
+    assert settings.incoming.use_ssl is False
+    assert settings.incoming.start_ssl is True
+
+
+def test_email_settings_from_env_accepts_imap_start_ssl(monkeypatch):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "secret")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "127.0.0.1")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_PORT", "1143")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_SSL", "false")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_START_SSL", "true")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "127.0.0.1")
+
+    settings = EmailSettings.from_env()
+
+    assert settings is not None
+    assert settings.incoming.use_ssl is False
+    assert settings.incoming.start_ssl is True
+
+
+def test_create_starttls_ssl_context_verify_false_is_permissive():
+    ctx = _create_starttls_ssl_context(False)
+
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+@pytest.mark.asyncio
+async def test_imap_starttls_upgrades_transport_and_refreshes_capabilities():
+    imap = _make_imap()
+    tls_transport = MagicMock()
+
+    with patch("asyncio.get_running_loop") as mock_get_loop:
+        mock_loop = MagicMock()
+        mock_loop.start_tls = AsyncMock(return_value=tls_transport)
+        mock_get_loop.return_value = mock_loop
+
+        await _imap_starttls(imap, ssl.create_default_context(), "127.0.0.1")
+
+    imap.protocol.execute.assert_awaited_once()
+    mock_loop.start_tls.assert_awaited_once()
+    assert imap.protocol.transport is tls_transport
+    imap.protocol.capability.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_imap_starttls_requires_server_capability():
+    imap = _make_imap(capabilities=("IMAP4rev1",))
+
+    with pytest.raises(OSError, match="does not advertise STARTTLS"):
+        await _imap_starttls(imap, ssl.create_default_context(), "127.0.0.1")
+
+
+@pytest.mark.asyncio
+async def test_imap_starttls_raises_when_command_fails():
+    imap = _make_imap()
+    imap.protocol.execute = AsyncMock(return_value=Response("NO"))
+
+    with pytest.raises(OSError, match="STARTTLS command failed: NO"):
+        await _imap_starttls(imap, ssl.create_default_context(), "127.0.0.1")
+
+
+@pytest.mark.asyncio
+async def test_connect_imap_uses_implicit_tls_when_use_ssl_true():
+    server = EmailServer(
+        user_name="user",
+        password="secret",
+        host="imap.example.com",
+        port=993,
+        use_ssl=True,
+        verify_ssl=False,
+    )
+    mock_imap = _make_imap()
+
+    with patch("mcp_email_server.emails.classic.aioimaplib.IMAP4_SSL", return_value=mock_imap) as mock_ssl:
+        result = await EmailClient._connect_imap_server(server)
+
+    assert result is mock_imap
+    mock_ssl.assert_called_once()
+    assert mock_ssl.call_args.kwargs["ssl_context"].verify_mode == ssl.CERT_NONE
+    mock_imap.wait_hello_from_server.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_imap_uses_plain_connection_without_starttls():
+    server = EmailServer(
+        user_name="user",
+        password="secret",
+        host="imap.example.com",
+        port=143,
+        use_ssl=False,
+        start_ssl=False,
+    )
+    mock_imap = _make_imap()
+
+    with patch("mcp_email_server.emails.classic.aioimaplib.IMAP4", return_value=mock_imap) as mock_plain:
+        with patch("mcp_email_server.emails.classic._imap_starttls", new=AsyncMock()) as mock_starttls:
+            result = await EmailClient._connect_imap_server(server)
+
+    assert result is mock_imap
+    mock_plain.assert_called_once_with("imap.example.com", 143)
+    mock_starttls.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_imap_uses_starttls_when_configured():
+    server = EmailServer(
+        user_name="user",
+        password="secret",
+        host="127.0.0.1",
+        port=1143,
+        use_ssl=False,
+        start_ssl=True,
+        verify_ssl=False,
+    )
+    mock_imap = _make_imap()
+
+    with patch("mcp_email_server.emails.classic.aioimaplib.IMAP4", return_value=mock_imap) as mock_plain:
+        with patch("mcp_email_server.emails.classic._imap_starttls", new=AsyncMock()) as mock_starttls:
+            result = await EmailClient._connect_imap_server(server)
+
+    assert result is mock_imap
+    mock_plain.assert_called_once_with("127.0.0.1", 1143)
+    mock_starttls.assert_awaited_once()
+    starttls_context = mock_starttls.await_args.args[1]
+    assert starttls_context.verify_mode == ssl.CERT_NONE
+
+
+@pytest.mark.asyncio
+async def test_append_to_mailbox_uses_incoming_starttls_path():
+    outgoing = EmailServer(user_name="user", password="secret", host="smtp.example.com", port=465)
+    incoming = EmailServer(
+        user_name="user",
+        password="secret",
+        host="127.0.0.1",
+        port=1143,
+        use_ssl=False,
+        start_ssl=True,
+        verify_ssl=False,
+    )
+    client = EmailClient(outgoing)
+    mock_imap = _make_imap()
+    mock_imap.login = AsyncMock(return_value=Response("OK"))
+    mock_imap.select = AsyncMock(return_value=("OK", []))
+    mock_imap.append = AsyncMock(return_value=("OK", []))
+    mock_imap.logout = AsyncMock()
+
+    with patch("mcp_email_server.emails.classic.aioimaplib.IMAP4", return_value=mock_imap):
+        with patch("mcp_email_server.emails.classic._imap_starttls", new=AsyncMock()) as mock_starttls:
+            result = await client.append_to_mailbox(MagicMock(as_bytes=lambda: b"message"), incoming, "Drafts")
+
+    assert result == "unknown"
+    mock_starttls.assert_awaited_once()
+    mock_imap.append.assert_awaited_once()


### PR DESCRIPTION
## Summary

Adds focused IMAP STARTTLS support while preserving the existing `use_ssl` / `start_ssl` / `verify_ssl` configuration shape.

## Changes

- Adds IMAP STARTTLS upgrade support using `asyncio.loop.start_tls()`.
- Reuses current IMAP config fields:
  - `use_ssl=true`: implicit TLS, usually port 993
  - `use_ssl=false` + `start_ssl=true`: STARTTLS, usually port 143 or bridge-specific ports
  - `verify_ssl=false`: permits self-signed local bridge certificates
- Adds `MCP_EMAIL_SERVER_IMAP_START_SSL` env var.
- Routes all IMAP connection paths through shared connection preparation:
  - metadata fetch
  - email content fetch
  - attachment download
  - save to Sent / save to mailbox
  - delete, mark read, move, list mailboxes
- Documents ProtonMail Bridge-style IMAP STARTTLS configuration.
- Adds focused tests for config/env parsing, TLS/plain/STARTTLS connection paths, STARTTLS failure handling, and mailbox append behavior.

## Verification

- `uv run ruff check mcp_email_server tests/test_imap_starttls.py`
- `uv run pytest -q`
- Network smoke test:
  - `imap.gmail.com:993` implicit TLS greeting/capabilities succeeded
  - `smtp.gmail.com:465` implicit TLS connection succeeded

`SMTP 587` connection timed out from the current network environment; this PR does not change the existing SMTP STARTTLS path.
