### PR TITLE
fix(imap): surface SELECT failures before mailbox operations

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -78,10 +78,29 @@ def _imap_status(response: Any) -> str:
     return str(response).upper()
 
 
+def _format_imap_response_detail(response: Any) -> str:
+    """Return a compact, readable IMAP response detail string."""
+    status = _imap_status(response)
+    lines = getattr(response, "lines", None)
+    if lines is None and isinstance(response, tuple) and len(response) > 1:
+        lines = response[1]
+
+    detail_parts = []
+    for line in lines or []:
+        if isinstance(line, bytes):
+            detail_parts.append(line.decode("utf-8", errors="replace"))
+        else:
+            detail_parts.append(str(line))
+
+    detail = " ".join(part for part in detail_parts if part).strip()
+    return f"{status} {detail}".strip()
+
+
 def _raise_for_imap_error(response: Any, operation: str) -> None:
     """Raise when an IMAP command returns a non-OK status."""
     if _imap_status(response) != "OK":
-        msg = f"{operation} failed: {response!r}"
+        detail = _format_imap_response_detail(response)
+        msg = f"{operation} failed" + (f": {detail}" if detail else "")
         raise RuntimeError(msg)
 
 
@@ -619,7 +638,8 @@ class EmailClient:
             # Login and select mailbox
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
-            await imap.select(_quote_mailbox(mailbox))
+            select_response = await imap.select(_quote_mailbox(mailbox))
+            _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
 
             search_criteria = self._build_search_criteria(
                 before,
@@ -792,7 +812,8 @@ class EmailClient:
         try:
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
-            await imap.select(_quote_mailbox(mailbox))
+            select_response = await imap.select(_quote_mailbox(mailbox))
+            _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
 
             data = await self._fetch_email_with_formats(imap, email_id)
             if not data:
@@ -1190,7 +1211,8 @@ class EmailClient:
         try:
             await _imap_login(imap, self.email_server.user_name, self.email_server.password.get_secret_value())
             await _send_imap_id(imap)
-            await imap.select(_quote_mailbox(mailbox))
+            select_response = await imap.select(_quote_mailbox(mailbox))
+            _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
 
             for email_id in email_ids:
                 try:

--- a/tests/test_email_attachments.py
+++ b/tests/test_email_attachments.py
@@ -251,6 +251,38 @@ class TestDownloadAttachmentMailboxParam:
                 mock_imap.select.assert_called_once_with('"INBOX"')
 
     @pytest.mark.asyncio
+    async def test_download_attachment_raises_on_select_failure(self, email_client, tmp_path):
+        """Test download stops when mailbox selection fails."""
+        import asyncio
+
+        save_path = str(tmp_path / "attachment.pdf")
+
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("NO", [b"[NONEXISTENT] Unknown Mailbox: Archive"]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "_fetch_email_with_formats", return_value=None) as mock_fetch:
+            with patch.object(email_client, "imap_class", return_value=mock_imap):
+                with pytest.raises(RuntimeError) as exc_info:
+                    await email_client.download_attachment(
+                        email_id="123",
+                        attachment_name="document.pdf",
+                        save_path=save_path,
+                        mailbox="Archive",
+                    )
+
+        message = str(exc_info.value)
+        assert "SELECT mailbox Archive failed" in message
+        assert "NO" in message
+        assert "[NONEXISTENT] Unknown Mailbox: Archive" in message
+        mock_fetch.assert_not_called()
+        mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_download_attachment_custom_mailbox(self, email_client, tmp_path):
         """Test download_attachment with custom mailbox parameter."""
         import asyncio

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -252,7 +252,7 @@ class TestEmailClient:
         mock_imap._client_task.set_result(None)
         mock_imap.wait_hello_from_server = AsyncMock()
         mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
-        mock_imap.select = AsyncMock()
+        mock_imap.select = AsyncMock(return_value=("OK", []))
         mock_imap.uid_search = AsyncMock(return_value=(None, [b"1 2 3"]))
         mock_imap.logout = AsyncMock()
 
@@ -310,6 +310,50 @@ class TestEmailClient:
                     mock_fetch_dates.assert_called_once_with(mock_imap, [b"1", b"2", b"3"])
                     # Headers fetched for page UIDs in sorted order (desc by date)
                     mock_fetch_headers.assert_called_once_with(mock_imap, ["3", "2", "1"])
+
+    @pytest.mark.asyncio
+    async def test_get_emails_metadata_raises_on_select_failure(self, email_client):
+        """Test mailbox selection failures are surfaced before SEARCH."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("NO", [b"[NONEXISTENT] Unknown Mailbox: Archive"]))
+        mock_imap.uid_search = AsyncMock()
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with pytest.raises(RuntimeError) as exc_info:
+                await email_client.get_emails_metadata(mailbox="Archive")
+
+        message = str(exc_info.value)
+        assert "SELECT mailbox Archive failed" in message
+        assert "NO" in message
+        assert "[NONEXISTENT] Unknown Mailbox: Archive" in message
+        mock_imap.uid_search.assert_not_called()
+        mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_emails_raises_on_select_failure(self, email_client):
+        """Test delete stops when mailbox selection fails."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("NO", [b"[NONEXISTENT] Unknown Mailbox: Archive"]))
+        mock_imap.uid = AsyncMock()
+        mock_imap.expunge = AsyncMock()
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with pytest.raises(RuntimeError, match="SELECT mailbox Archive failed"):
+                await email_client.delete_emails(["123"], mailbox="Archive")
+
+        mock_imap.uid.assert_not_called()
+        mock_imap.expunge.assert_not_called()
+        mock_imap.logout.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_send_email(self, email_client):


### PR DESCRIPTION
## Summary
- check IMAP SELECT responses before metadata search, attachment fetch, and delete operations
- include decoded IMAP response details in raised errors
- add regression tests for SELECT failures so follow-up SEARCH/FETCH/STORE commands are skipped

Fixes #162.

## Tests
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .