### PR TITLE
fix(email): parse HTML fallback with BeautifulSoup

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import aioimaplib
 import aiosmtplib
+from bs4 import BeautifulSoup
 
 from mcp_email_server.config import EmailServer, EmailSettings
 from mcp_email_server.emails import EmailHandler
@@ -103,6 +104,18 @@ def _raise_for_imap_error(response: Any, operation: str) -> None:
         detail = _format_imap_response_detail(response)
         msg = f"{operation} failed" + (f": {detail}" if detail else "")
         raise RuntimeError(msg)
+
+
+def _html_to_text(html: str) -> str:
+    """Convert an HTML email body to readable plain text."""
+    soup = BeautifulSoup(html, "html.parser")
+    for element in soup(["script", "style"]):
+        element.decompose()
+
+    text = soup.get_text(separator="\n")
+    text = re.sub(r"\n\s*\n", "\n\n", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    return text.strip()
 
 
 async def _send_imap_id(imap: aioimaplib.IMAP4 | aioimaplib.IMAP4_SSL) -> None:
@@ -360,25 +373,6 @@ class EmailClient:
         html_body = ""  # Fallback if no text/plain
         attachments = []
 
-        def _strip_html(html: str) -> str:
-            """Simple HTML to text conversion."""
-            import re
-
-            # Remove script and style elements
-            text = re.sub(r"<(script|style)[^>]*>.*?</\1>", "", html, flags=re.DOTALL | re.IGNORECASE)
-            # Convert common block elements to newlines
-            text = re.sub(r"<(br|p|div|tr|li)[^>]*/?>", "\n", text, flags=re.IGNORECASE)
-            # Remove all remaining HTML tags
-            text = re.sub(r"<[^>]+>", "", text)
-            # Decode common HTML entities
-            text = text.replace("&nbsp;", " ").replace("&amp;", "&")
-            text = text.replace("&lt;", "<").replace("&gt;", ">")
-            text = text.replace("&quot;", '"').replace("&#39;", "'")
-            # Collapse multiple newlines and whitespace
-            text = re.sub(r"\n\s*\n", "\n\n", text)
-            text = re.sub(r" +", " ", text)
-            return text.strip()
-
         if email_message.is_multipart():
             for part in email_message.walk():
                 content_type = part.get_content_type()
@@ -410,7 +404,7 @@ class EmailClient:
 
             # Fall back to HTML if no plain text found
             if not body and html_body:
-                body = _strip_html(html_body)
+                body = _html_to_text(html_body)
         else:
             # Handle single-part emails
             content_type = email_message.get_content_type()
@@ -422,7 +416,7 @@ class EmailClient:
                 except UnicodeDecodeError:
                     text = payload.decode("utf-8", errors="replace")
 
-                body = _strip_html(text) if content_type == "text/html" else text
+                body = _html_to_text(text) if content_type == "text/html" else text
         # TODO: Allow retrieving full email body
         if body and len(body) > MAX_BODY_LENGTH:
             body = body[:MAX_BODY_LENGTH] + "...[TRUNCATED]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "aioimaplib>=2.0.1",
     "aiosmtplib>=4.0.0",
+    "beautifulsoup4>=4.14.3",
     "gradio>=6.0.1",
     "jinja2>=3.1.5",
     "loguru>=0.7.3",

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mcp_email_server.config import EmailServer
-from mcp_email_server.emails.classic import EmailClient, _create_smtp_ssl_context, _imap_login
+from mcp_email_server.emails.classic import EmailClient, _create_smtp_ssl_context, _html_to_text, _imap_login
 
 
 @pytest.fixture
@@ -94,6 +94,66 @@ class TestEmailClient:
         assert result["body"] == "This is a test email body"
         assert isinstance(result["date"], datetime)
         assert result["attachments"] == []
+
+    def test_html_to_text_removes_scripts_and_preserves_readable_text(self):
+        """HTML fallback extraction uses an HTML parser for readable plain text."""
+        html = """
+        <html>
+          <head><style>.hidden { display: none; }</style><script>alert('x')</script></head>
+          <body>
+            <h1>Title &amp; Updates</h1>
+            <p>Hello&nbsp;<strong>there</strong></p>
+            <div>Line<br>Break</div>
+            <ul><li>One</li><li>Two</li></ul>
+          </body>
+        </html>
+        """
+
+        result = _html_to_text(html)
+
+        assert "alert" not in result
+        assert "display" not in result
+        assert "Title & Updates" in result
+        assert "Hello" in result
+        assert "there" in result
+        assert "Line" in result
+        assert "Break" in result
+        assert "One" in result
+        assert "Two" in result
+
+    def test_parse_email_data_html_single_part_falls_back_to_text(self):
+        """Single-part HTML emails are converted to plain text."""
+        msg = MIMEText("<html><body><p>Hello&nbsp;<b>world</b></p><script>x()</script></body></html>", "html", "utf-8")
+        msg["Subject"] = "HTML Subject"
+        msg["From"] = "sender@example.com"
+        msg["To"] = "recipient@example.com"
+        msg["Date"] = email.utils.formatdate()
+
+        client = EmailClient(MagicMock())
+        result = client._parse_email_data(msg.as_bytes())
+
+        assert result["subject"] == "HTML Subject"
+        assert "Hello" in result["body"]
+        assert "world" in result["body"]
+        assert "script" not in result["body"]
+        assert "x()" not in result["body"]
+
+    def test_parse_email_data_html_fallback_when_plain_text_missing(self):
+        """Multipart emails use HTML fallback when text/plain is absent."""
+        from email.mime.multipart import MIMEMultipart
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = "HTML Only"
+        msg["From"] = "sender@example.com"
+        msg["To"] = "recipient@example.com"
+        msg["Date"] = email.utils.formatdate()
+        msg.attach(MIMEText("<div>First</div><div>Second &amp; third</div>", "html", "utf-8"))
+
+        client = EmailClient(MagicMock())
+        result = client._parse_email_data(msg.as_bytes())
+
+        assert "First" in result["body"]
+        assert "Second & third" in result["body"]
 
     def test_parse_email_data_with_attachments(self):
         """Test parsing email with attachments."""

--- a/uv.lock
+++ b/uv.lock
@@ -157,6 +157,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "brotli"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1065,6 +1078,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aioimaplib" },
     { name = "aiosmtplib" },
+    { name = "beautifulsoup4" },
     { name = "gradio" },
     { name = "jinja2" },
     { name = "loguru" },
@@ -1093,6 +1107,7 @@ dev = [
 requires-dist = [
     { name = "aioimaplib", specifier = ">=2.0.1" },
     { name = "aiosmtplib", specifier = ">=4.0.0" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "gradio", specifier = ">=6.0.1" },
     { name = "jinja2", specifier = ">=3.1.5" },
     { name = "loguru", specifier = ">=0.7.3" },
@@ -2380,6 +2395,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the regex-based HTML fallback stripper with BeautifulSoup using the built-in html.parser
- keep the scope limited to fallback text extraction for HTML email bodies
- add regression tests for script/style removal, entity decoding, single-part HTML, and multipart HTML fallback

Addresses #154.

## Tests
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .