### PR TITLE
fix(imap): fall back to UID order when dates are missing

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -71,6 +71,12 @@ def _quote_mailbox(mailbox: str) -> str:
     return f'"{escaped}"'
 
 
+def _uid_sort_key(uid: bytes | str) -> int:
+    """Return a numeric sort key for IMAP UIDs."""
+    value = uid.decode() if isinstance(uid, bytes) else uid
+    return int(value)
+
+
 def _imap_status(response: Any) -> str:
     """Return the normalized status from an aioimaplib response."""
     if hasattr(response, "result"):
@@ -669,12 +675,39 @@ class EmailClient:
             uid_dates = await self._batch_fetch_dates(imap, email_ids)
             fetch_dates_elapsed = time.perf_counter() - fetch_dates_start
 
-            # Sort by INTERNALDATE
-            sorted_uids = sorted(uid_dates.items(), key=lambda x: x[1], reverse=(order == "desc"))
+            missing_date_count = len(email_ids) - len(uid_dates)
+            if missing_date_count:
+                logger.warning(
+                    f"Missing INTERNALDATE for {missing_date_count}/{len(email_ids)} searched UIDs; "
+                    "falling back to UID order for those messages"
+                )
+
+            # Keep UID SEARCH results as the source of truth. Use INTERNALDATE where
+            # available, and fall back to UID ordering for provider-specific
+            # INTERNALDATE response formats that cannot be parsed.
+            if order == "desc":
+                sorted_uids = sorted(
+                    (uid.decode() for uid in email_ids),
+                    key=lambda uid: (
+                        uid_dates.get(uid) is not None,
+                        uid_dates.get(uid) or datetime.min.replace(tzinfo=timezone.utc),
+                        _uid_sort_key(uid),
+                    ),
+                    reverse=True,
+                )
+            else:
+                sorted_uids = sorted(
+                    (uid.decode() for uid in email_ids),
+                    key=lambda uid: (
+                        uid_dates.get(uid) is None,
+                        uid_dates.get(uid) or datetime.max.replace(tzinfo=timezone.utc),
+                        _uid_sort_key(uid),
+                    ),
+                )
 
             # Paginate
             start = (page - 1) * page_size
-            page_uids = [uid for uid, _ in sorted_uids[start : start + page_size]]
+            page_uids = sorted_uids[start : start + page_size]
 
             if not page_uids:
                 logger.info(f"Phase 1 (dates): {len(uid_dates)} UIDs in {fetch_dates_elapsed:.2f}s, page {page} empty")

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -372,6 +372,58 @@ class TestEmailClient:
                     mock_fetch_headers.assert_called_once_with(mock_imap, ["3", "2", "1"])
 
     @pytest.mark.asyncio
+    async def test_get_emails_metadata_falls_back_to_uid_order_when_dates_missing(self, email_client):
+        """Metadata listing should still return emails when INTERNALDATE parsing fails."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b"1 2 3"]))
+        mock_imap.logout = AsyncMock()
+
+        mock_metadata = {
+            "1": {
+                "email_id": "1",
+                "subject": "Subject 1",
+                "from": "a@test.com",
+                "to": [],
+                "date": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+            "2": {
+                "email_id": "2",
+                "subject": "Subject 2",
+                "from": "b@test.com",
+                "to": [],
+                "date": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+            "3": {
+                "email_id": "3",
+                "subject": "Subject 3",
+                "from": "c@test.com",
+                "to": [],
+                "date": datetime(2024, 1, 3, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+        }
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_dates", return_value={}) as mock_fetch_dates:
+                with patch.object(
+                    email_client, "_batch_fetch_headers", return_value=mock_metadata
+                ) as mock_fetch_headers:
+                    total, emails = await email_client.get_emails_metadata(page=1, page_size=2)
+
+        assert total == 3
+        assert [email["email_id"] for email in emails] == ["3", "2"]
+        mock_fetch_dates.assert_called_once_with(mock_imap, [b"1", b"2", b"3"])
+        mock_fetch_headers.assert_called_once_with(mock_imap, ["3", "2"])
+        mock_imap.logout.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_get_emails_metadata_raises_on_select_failure(self, email_client):
         """Test mailbox selection failures are surfaced before SEARCH."""
         mock_imap = AsyncMock()


### PR DESCRIPTION
## Summary
- keep UID SEARCH results as the metadata source of truth
- fall back to numeric UID ordering when INTERNALDATE cannot be parsed
- add regression coverage for non-zero search results with missing dates

Fixes #141

## Tests
- uv run pytest tests/test_email_client.py -q
- uv run pytest -q
- uv run ruff check mcp_email_server/emails/classic.py tests/test_email_client.py
- uv run ruff format --check mcp_email_server/emails/classic.py tests/test_email_client.py