### PR TITLE
feat(config): support read-only email accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                        | `true`        | No       |
 | `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                   | `false`       | No       |
 | `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed) | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host                                       | -             | Yes      |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for read-only mode              | -             | No       |
 | `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                       | `465`         | No       |
 | `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                        | `true`        | No       |
 | `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                        | `false`       | No       |
@@ -83,6 +83,26 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                             | `false`       | No       |
 | `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                   | `true`        | No       |
 | `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)       | -             | No       |
+
+### Read-only IMAP mode
+
+SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, the account runs in read-only mode and exposes only read/mailbox-management tools. Outbound compose tools such as `send_email` and `save_to_mailbox` are hidden when every configured email account is read-only.
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
+        "MCP_EMAIL_SERVER_PASSWORD": "your_password",
+        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.gmail.com"
+      }
+    }
+  }
+}
+```
 
 ### HTTP Transport Security
 

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from datetime import datetime
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -18,7 +19,44 @@ from mcp_email_server.emails.models import (
     MailboxInfo,
 )
 
-mcp = FastMCP("email")
+ToolVisibilityPredicate = Callable[[], bool]
+
+
+def _has_send_capable_account() -> bool:
+    settings = get_settings()
+    return any(isinstance(account, EmailSettings) and account.can_send for account in settings.get_accounts())
+
+
+class VisibilityAwareFastMCP(FastMCP):
+    """FastMCP server with declarative tool visibility predicates."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._tool_visibility: dict[str, ToolVisibilityPredicate] = {}
+
+    def tool(
+        self,
+        name: str | None = None,
+        *,
+        visible_if: ToolVisibilityPredicate | None = None,
+        **kwargs: Any,
+    ) -> Callable[[Any], Any]:
+        decorator = super().tool(name=name, **kwargs)
+
+        def wrapped(fn: Any) -> Any:
+            registered = decorator(fn)
+            if visible_if is not None:
+                self._tool_visibility[name or fn.__name__] = visible_if
+            return registered
+
+        return wrapped
+
+    async def list_tools(self):
+        tools = await super().list_tools()
+        return [tool for tool in tools if self._tool_visibility.get(tool.name, lambda: True)()]
+
+
+mcp = VisibilityAwareFastMCP("email")
 
 
 @mcp.resource("email://{account_name}")
@@ -127,6 +165,7 @@ async def get_emails_content(
 
 @mcp.tool(
     description="Send an email using the specified account. Supports replying to emails with proper threading when in_reply_to is provided.",
+    visible_if=_has_send_capable_account,
 )
 async def send_email(
     account_name: Annotated[str, Field(description="The name of the email account to send from.")],
@@ -188,6 +227,7 @@ async def send_email(
     description="Compose an email and save it to an IMAP folder (e.g., Drafts). "
     "Same parameters as send_email, but saves instead of sending. "
     "Default folder is Drafts with \\Draft and \\Seen flags.",
+    visible_if=_has_send_capable_account,
 )
 async def save_to_mailbox(
     account_name: Annotated[str, Field(description="The name of the email account.")],

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -87,9 +87,14 @@ class EmailSettings(AccountAttributes):
     full_name: str
     email_address: str
     incoming: EmailServer
-    outgoing: EmailServer
+    outgoing: EmailServer | None = None
     save_to_sent: bool = True  # Save sent emails to IMAP Sent folder
     sent_folder_name: str | None = None  # Override Sent folder name (auto-detect if None)
+
+    @property
+    def can_send(self) -> bool:
+        """Return whether this account has SMTP configuration."""
+        return self.outgoing is not None
 
     @classmethod
     def init(
@@ -101,7 +106,7 @@ class EmailSettings(AccountAttributes):
         user_name: str,
         password: str,
         imap_host: str,
-        smtp_host: str,
+        smtp_host: str | None = None,
         imap_user_name: str | None = None,
         imap_password: str | None = None,
         imap_port: int = 993,
@@ -130,14 +135,18 @@ class EmailSettings(AccountAttributes):
                 start_ssl=imap_start_ssl,
                 verify_ssl=imap_verify_ssl,
             ),
-            outgoing=EmailServer(
-                user_name=smtp_user_name or user_name,
-                password=smtp_password or password,
-                host=smtp_host,
-                port=smtp_port,
-                use_ssl=smtp_ssl,
-                start_ssl=smtp_start_ssl,
-                verify_ssl=smtp_verify_ssl,
+            outgoing=(
+                EmailServer(
+                    user_name=smtp_user_name or user_name,
+                    password=smtp_password or password,
+                    host=smtp_host,
+                    port=smtp_port,
+                    use_ssl=smtp_ssl,
+                    start_ssl=smtp_start_ssl,
+                    verify_ssl=smtp_verify_ssl,
+                )
+                if smtp_host
+                else None
             ),
             save_to_sent=save_to_sent,
             sent_folder_name=sent_folder_name,
@@ -158,7 +167,7 @@ class EmailSettings(AccountAttributes):
         - MCP_EMAIL_SERVER_IMAP_SSL (default: true)
         - MCP_EMAIL_SERVER_IMAP_START_SSL (default: false)
         - MCP_EMAIL_SERVER_IMAP_VERIFY_SSL (default: true)
-        - MCP_EMAIL_SERVER_SMTP_HOST
+        - MCP_EMAIL_SERVER_SMTP_HOST (optional; enables send_email)
         - MCP_EMAIL_SERVER_SMTP_PORT (default: 465)
         - MCP_EMAIL_SERVER_SMTP_SSL (default: true)
         - MCP_EMAIL_SERVER_SMTP_START_SSL (default: false)
@@ -181,8 +190,8 @@ class EmailSettings(AccountAttributes):
         smtp_host = os.getenv("MCP_EMAIL_SERVER_SMTP_HOST")
 
         # Required fields check
-        if not imap_host or not smtp_host:
-            logger.warning("Missing required email configuration environment variables (IMAP_HOST or SMTP_HOST)")
+        if not imap_host:
+            logger.warning("Missing required email configuration environment variable: IMAP_HOST")
             return None
 
         try:
@@ -217,7 +226,7 @@ class EmailSettings(AccountAttributes):
         return self.model_copy(
             update={
                 "incoming": self.incoming.masked(),
-                "outgoing": self.outgoing.masked(),
+                "outgoing": self.outgoing.masked() if self.outgoing else None,
             }
         )
 

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1384,9 +1384,13 @@ class ClassicEmailHandler(EmailHandler):
     def __init__(self, email_settings: EmailSettings):
         self.email_settings = email_settings
         self.incoming_client = EmailClient(email_settings.incoming)
-        self.outgoing_client = EmailClient(
-            email_settings.outgoing,
-            sender=f"{email_settings.full_name} <{email_settings.email_address}>",
+        self.outgoing_client = (
+            EmailClient(
+                email_settings.outgoing,
+                sender=f"{email_settings.full_name} <{email_settings.email_address}>",
+            )
+            if email_settings.outgoing
+            else None
         )
         self.save_to_sent = email_settings.save_to_sent
         self.sent_folder_name = email_settings.sent_folder_name
@@ -1479,6 +1483,9 @@ class ClassicEmailHandler(EmailHandler):
         in_reply_to: str | None = None,
         references: str | None = None,
     ) -> None:
+        if self.outgoing_client is None:
+            raise RuntimeError(f"SMTP is not configured for account '{self.email_settings.account_name}'")
+
         msg = await self.outgoing_client.send_email(
             recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references
         )
@@ -1526,6 +1533,9 @@ class ClassicEmailHandler(EmailHandler):
             ValueError: If any flag in *flags* is invalid per RFC 3501.
             RuntimeError: If the IMAP APPEND operation fails.
         """
+        if self.outgoing_client is None:
+            raise RuntimeError(f"SMTP is not configured for account '{self.email_settings.account_name}'")
+
         msg = self.outgoing_client.compose_message(
             recipients,
             subject,

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -57,6 +57,26 @@ class TestClassicEmailHandler:
         assert handler.outgoing_client.email_server == email_settings.outgoing
         assert handler.outgoing_client.sender == f"{email_settings.full_name} <{email_settings.email_address}>"
 
+    def test_init_read_only_account(self):
+        """Read-only accounts initialize without an outgoing SMTP client."""
+        email_settings = EmailSettings(
+            account_name="read_only",
+            full_name="Read Only",
+            email_address="read-only@example.com",
+            incoming=EmailServer(
+                user_name="reader",
+                password="secret",
+                host="imap.example.com",
+                port=993,
+                use_ssl=True,
+            ),
+        )
+
+        handler = ClassicEmailHandler(email_settings)
+
+        assert isinstance(handler.incoming_client, EmailClient)
+        assert handler.outgoing_client is None
+
     @pytest.mark.asyncio
     async def test_get_emails(self, classic_handler):
         """Test get_emails method."""
@@ -198,6 +218,54 @@ class TestClassicEmailHandler:
                 [str(test_file)],
                 None,
                 None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_read_only_account_rejects_send_email(self):
+        """Read-only accounts cannot send email."""
+        email_settings = EmailSettings(
+            account_name="read_only",
+            full_name="Read Only",
+            email_address="read-only@example.com",
+            incoming=EmailServer(
+                user_name="reader",
+                password="secret",
+                host="imap.example.com",
+                port=993,
+                use_ssl=True,
+            ),
+        )
+        handler = ClassicEmailHandler(email_settings)
+
+        with pytest.raises(RuntimeError, match="SMTP is not configured"):
+            await handler.send_email(
+                recipients=["recipient@example.com"],
+                subject="Test Subject",
+                body="Test Body",
+            )
+
+    @pytest.mark.asyncio
+    async def test_read_only_account_rejects_save_to_mailbox(self):
+        """Read-only accounts cannot compose and save outbound drafts."""
+        email_settings = EmailSettings(
+            account_name="read_only",
+            full_name="Read Only",
+            email_address="read-only@example.com",
+            incoming=EmailServer(
+                user_name="reader",
+                password="secret",
+                host="imap.example.com",
+                port=993,
+                use_ssl=True,
+            ),
+        )
+        handler = ClassicEmailHandler(email_settings)
+
+        with pytest.raises(RuntimeError, match="SMTP is not configured"):
+            await handler.save_to_mailbox(
+                recipients=["recipient@example.com"],
+                subject="Test Subject",
+                body="Test Body",
             )
 
     @pytest.mark.asyncio

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,6 +54,28 @@ def test_api_key_is_secret_type():
     assert provider.api_key.get_secret_value() == "sk-123"
 
 
+def test_email_settings_without_outgoing_is_read_only():
+    """EmailSettings can represent read-only IMAP accounts."""
+    settings = EmailSettings(
+        account_name="read_only",
+        full_name="Read Only",
+        email_address="read-only@example.com",
+        incoming=EmailServer(
+            user_name="reader",
+            password="secret",
+            host="imap.example.com",
+            port=993,
+        ),
+    )
+
+    assert settings.outgoing is None
+    assert settings.can_send is False
+
+    masked = settings.masked()
+    assert masked.outgoing is None
+    assert masked.incoming.password.get_secret_value() == "********"
+
+
 def test_config():
     settings = get_settings()
     assert settings.emails == []

--- a/tests/test_env_config_coverage.py
+++ b/tests/test_env_config_coverage.py
@@ -23,8 +23,8 @@ def test_from_env_missing_email_and_password(monkeypatch):
     assert result is None
 
 
-def test_from_env_missing_hosts_warning(monkeypatch):
-    """Test logger.warning for missing hosts - covers lines 154-156."""
+def test_from_env_missing_imap_host_warning(monkeypatch):
+    """Test logger.warning for missing required IMAP host."""
     monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
     monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
 
@@ -32,16 +32,24 @@ def test_from_env_missing_hosts_warning(monkeypatch):
     result = EmailSettings.from_env()
     assert result is None
 
-    # Missing SMTP host
-    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.test.com")
-    result = EmailSettings.from_env()
-    assert result is None
-
     # Missing IMAP host
-    monkeypatch.delenv("MCP_EMAIL_SERVER_IMAP_HOST")
     monkeypatch.setenv("MCP_EMAIL_SERVER_SMTP_HOST", "smtp.test.com")
     result = EmailSettings.from_env()
     assert result is None
+
+
+def test_from_env_without_smtp_host_creates_read_only_account(monkeypatch):
+    """Test SMTP host is optional for read-only accounts."""
+    monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "test@example.com")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "pass")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.test.com")
+
+    result = EmailSettings.from_env()
+
+    assert result is not None
+    assert result.incoming.host == "imap.test.com"
+    assert result.outgoing is None
+    assert result.can_send is False
 
 
 def test_from_env_exception_handling(monkeypatch):
@@ -70,6 +78,7 @@ def test_from_env_success_with_all_defaults(monkeypatch):
     assert result.email_address == "user@example.com"
     assert result.incoming.user_name == "user@example.com"
     assert result.incoming.port == 993
+    assert result.outgoing is not None
     assert result.outgoing.port == 465
 
 
@@ -105,6 +114,7 @@ def test_from_env_with_all_vars_set(monkeypatch):
     assert result.incoming.password.get_secret_value() == "imap_pass"
     assert result.incoming.port == 143
     assert result.incoming.use_ssl is False
+    assert result.outgoing is not None
     assert result.outgoing.user_name == "smtp_john"
     assert result.outgoing.password.get_secret_value() == "smtp_pass"
     assert result.outgoing.port == 587
@@ -129,6 +139,7 @@ def test_from_env_boolean_parsing_variations(monkeypatch):
 
     result = EmailSettings.from_env()
     assert result.incoming.use_ssl is True
+    assert result.outgoing is not None
     assert result.outgoing.use_ssl is False
 
     # Test "on"/"off"
@@ -137,6 +148,7 @@ def test_from_env_boolean_parsing_variations(monkeypatch):
 
     result = EmailSettings.from_env()
     assert result.incoming.use_ssl is True
+    assert result.outgoing is not None
     assert result.outgoing.start_ssl is False
 
 
@@ -170,6 +182,47 @@ def test_settings_init_add_new_account(monkeypatch, tmp_path):
     settings = Settings()
     assert len(settings.emails) == 1
     assert settings.emails[0].account_name == "newaccount"
+
+
+def test_settings_init_add_read_only_account_from_env(monkeypatch, tmp_path):
+    """Test adding a read-only account from env without SMTP config."""
+    config_file = tmp_path / "empty.toml"
+    config_file.write_text("")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CONFIG_PATH", str(config_file))
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ACCOUNT_NAME", "read_only")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "reader@example.com")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "readpass")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.reader.com")
+    monkeypatch.delenv("MCP_EMAIL_SERVER_SMTP_HOST", raising=False)
+
+    settings = Settings()
+
+    assert len(settings.emails) == 1
+    assert settings.emails[0].account_name == "read_only"
+    assert settings.emails[0].incoming.host == "imap.reader.com"
+    assert settings.emails[0].outgoing is None
+    assert settings.emails[0].can_send is False
+
+
+def test_email_settings_loads_read_only_account_without_outgoing_block():
+    """Test email accounts can omit outgoing SMTP configuration."""
+    email = EmailSettings.model_validate({
+        "account_name": "read_only",
+        "full_name": "Read Only",
+        "email_address": "reader@example.com",
+        "incoming": {
+            "user_name": "reader",
+            "password": "readpass",
+            "host": "imap.reader.com",
+            "port": 993,
+            "use_ssl": True,
+        },
+    })
+
+    assert email.account_name == "read_only"
+    assert email.outgoing is None
+    assert email.can_send is False
 
 
 def test_settings_init_override_existing(monkeypatch, tmp_path):
@@ -307,6 +360,7 @@ def test_email_settings_masked(monkeypatch):
 
     masked = email.masked()
     assert masked.incoming.password.get_secret_value() == "********"
+    assert masked.outgoing is not None
     assert masked.outgoing.password.get_secret_value() == "********"
     assert masked.email_address == "test@example.com"
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from mcp_email_server import app as app_module
 from mcp_email_server.app import (
     add_email_account,
     delete_emails,
@@ -360,6 +361,63 @@ class TestMcpTools:
 
             assert result == batch_response
             mock_handler.get_emails_content.assert_called_once_with(["12345"], "Sent", False)
+
+    @pytest.mark.asyncio
+    async def test_tool_visibility_hides_outbound_tools_for_read_only_accounts(self):
+        """Read-only deployments should hide outbound tools from MCP clients."""
+        read_only_account = EmailSettings(
+            account_name="read_only",
+            full_name="Read Only",
+            email_address="read-only@example.com",
+            incoming=EmailServer(
+                user_name="reader",
+                password="secret",
+                host="imap.example.com",
+                port=993,
+                use_ssl=True,
+            ),
+        )
+        mock_settings = MagicMock()
+        mock_settings.get_accounts.return_value = [read_only_account]
+
+        with patch("mcp_email_server.app.get_settings", return_value=mock_settings):
+            tool_names = {tool.name for tool in await app_module.mcp.list_tools()}
+
+        assert "send_email" not in tool_names
+        assert "save_to_mailbox" not in tool_names
+        assert "list_emails_metadata" in tool_names
+        assert "get_emails_content" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_tool_visibility_shows_outbound_tools_for_send_capable_accounts(self):
+        """SMTP-configured deployments should expose outbound tools."""
+        send_capable_account = EmailSettings(
+            account_name="send_capable",
+            full_name="Send Capable",
+            email_address="sender@example.com",
+            incoming=EmailServer(
+                user_name="reader",
+                password="secret",
+                host="imap.example.com",
+                port=993,
+                use_ssl=True,
+            ),
+            outgoing=EmailServer(
+                user_name="sender",
+                password="secret",
+                host="smtp.example.com",
+                port=465,
+                use_ssl=True,
+            ),
+        )
+        mock_settings = MagicMock()
+        mock_settings.get_accounts.return_value = [send_capable_account]
+
+        with patch("mcp_email_server.app.get_settings", return_value=mock_settings):
+            tool_names = {tool.name for tool in await app_module.mcp.list_tools()}
+
+        assert "send_email" in tool_names
+        assert "save_to_mailbox" in tool_names
 
     @pytest.mark.asyncio
     async def test_send_email(self):


### PR DESCRIPTION
## Summary
- allow email accounts to omit SMTP/outgoing configuration for read-only IMAP setups
- hide outbound compose tools when every configured email account is read-only
- keep read/mailbox tools available for read-only accounts
- document read-only IMAP mode and add regression coverage

Fixes #129

## Tests
- uv run pytest -q
- uv run ruff check mcp_email_server/app.py mcp_email_server/config.py mcp_email_server/emails/classic.py tests/test_config.py tests/test_env_config_coverage.py tests/test_classic_handler.py tests/test_mcp_tools.py
- uv run ruff format --check mcp_email_server/app.py mcp_email_server/config.py mcp_email_server/emails/classic.py tests/test_config.py tests/test_env_config_coverage.py tests/test_classic_handler.py tests/test_mcp_tools.py