### PR TITLE
Add reply_to parameter to send_email

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -205,6 +205,13 @@ async def send_email(
             description="Space-separated Message-IDs for the thread chain. Usually includes in_reply_to plus ancestors.",
         ),
     ] = None,
+    reply_to: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Email address to set as the Reply-To header. When set, email clients will reply to this address instead of the From address.",
+        ),
+    ] = None,
 ) -> str:
     handler = dispatch_handler(account_name)
     await handler.send_email(
@@ -217,6 +224,7 @@ async def send_email(
         attachments,
         in_reply_to,
         references,
+        reply_to,
     )
     recipient_str = ", ".join(recipients)
     attachment_info = f" with {len(attachments)} attachment(s)" if attachments else ""

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -66,6 +66,7 @@ class EmailHandler(abc.ABC):
         attachments: list[str] | None = None,
         in_reply_to: str | None = None,
         references: str | None = None,
+        reply_to: str | None = None,
     ) -> None:
         """
         Send email
@@ -80,6 +81,7 @@ class EmailHandler(abc.ABC):
             attachments: List of file paths to attach.
             in_reply_to: Message-ID of the email being replied to (for threading).
             references: Space-separated Message-IDs for the thread chain.
+            reply_to: Address to set as Reply-To header (overrides From for replies).
         """
 
     @abc.abstractmethod

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1040,7 +1040,9 @@ class EmailClient:
         references: str | None = None,
         reply_to: str | None = None,
     ) -> MIMEText | MIMEMultipart:
-        msg = self.compose_message(recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references, reply_to)
+        msg = self.compose_message(
+            recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references, reply_to
+        )
 
         async with aiosmtplib.SMTP(
             hostname=self.email_server.host,

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -971,6 +971,7 @@ class EmailClient:
         in_reply_to: str | None = None,
         references: str | None = None,
         include_bcc_header: bool = False,
+        reply_to: str | None = None,
     ) -> MIMEText | MIMEMultipart:
         """Compose an email message without sending it.
 
@@ -1016,6 +1017,8 @@ class EmailClient:
             msg["In-Reply-To"] = in_reply_to
         if references:
             msg["References"] = references
+        if reply_to:
+            msg["Reply-To"] = reply_to
 
         # Set Date and Message-Id headers
         msg["Date"] = email.utils.formatdate(localtime=True)
@@ -1035,8 +1038,9 @@ class EmailClient:
         attachments: list[str] | None = None,
         in_reply_to: str | None = None,
         references: str | None = None,
+        reply_to: str | None = None,
     ) -> MIMEText | MIMEMultipart:
-        msg = self.compose_message(recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references)
+        msg = self.compose_message(recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references, reply_to)
 
         async with aiosmtplib.SMTP(
             hostname=self.email_server.host,
@@ -1482,12 +1486,13 @@ class ClassicEmailHandler(EmailHandler):
         attachments: list[str] | None = None,
         in_reply_to: str | None = None,
         references: str | None = None,
+        reply_to: str | None = None,
     ) -> None:
         if self.outgoing_client is None:
             raise RuntimeError(f"SMTP is not configured for account '{self.email_settings.account_name}'")
 
         msg = await self.outgoing_client.send_email(
-            recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references
+            recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references, reply_to
         )
 
         # Save to Sent folder if enabled

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1041,7 +1041,7 @@ class EmailClient:
         reply_to: str | None = None,
     ) -> MIMEText | MIMEMultipart:
         msg = self.compose_message(
-            recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references, reply_to
+            recipients, subject, body, cc, bcc, html, attachments, in_reply_to, references, False, reply_to
         )
 
         async with aiosmtplib.SMTP(

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -185,6 +185,7 @@ class TestClassicEmailHandler:
                 None,
                 None,
                 None,
+                None,
             )
 
     @pytest.mark.asyncio
@@ -216,6 +217,7 @@ class TestClassicEmailHandler:
                 None,
                 False,
                 [str(test_file)],
+                None,
                 None,
                 None,
             )

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -415,6 +415,27 @@ class TestClassicEmailHandler:
             assert msg["References"] == "<original@example.com>"
 
     @pytest.mark.asyncio
+    async def test_send_email_with_reply_to(self, classic_handler):
+        """Test sending email with Reply-To header."""
+        mock_smtp = AsyncMock()
+        mock_smtp.__aenter__.return_value = mock_smtp
+        mock_smtp.__aexit__.return_value = None
+        mock_smtp.login = AsyncMock()
+        mock_smtp.send_message = AsyncMock()
+
+        with patch("aiosmtplib.SMTP", return_value=mock_smtp):
+            await classic_handler.send_email(
+                recipients=["recipient@example.com"],
+                subject="Test",
+                body="Body",
+                reply_to="replyhere@example.com",
+            )
+
+            call_args = mock_smtp.send_message.call_args
+            msg = call_args[0][0]
+            assert msg["Reply-To"] == "replyhere@example.com"
+
+    @pytest.mark.asyncio
     async def test_get_emails_content_includes_message_id(self, classic_handler):
         """Test that get_emails_content returns message_id from parsed email data."""
         now = datetime.now(timezone.utc)

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -450,6 +450,7 @@ class TestMcpTools:
                 None,
                 None,  # in_reply_to
                 None,  # references
+                None,  # reply_to
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Allow setting a reply-to when sending an email.

This allows my agent to send me emails using the Gmail SMTP, while authenticated as me, and still set the reply-to to the agent's email.