### PR TITLE
fix(imap): handle modified UTF-7 mailbox names

### DIFF
--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -7,7 +7,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 import tomli_w
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_serializer, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_serializer, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -48,25 +48,16 @@ class EmailServer(BaseModel):
 
 
 class AccountAttributes(BaseModel):
-    model_config = ConfigDict(json_encoders={datetime.datetime: lambda v: v.isoformat()})
     account_name: str
     description: str = ""
     created_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(ZoneInfo("UTC")))
     updated_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(ZoneInfo("UTC")))
 
     @model_validator(mode="after")
-    @classmethod
-    def update_updated_at(cls, obj: AccountAttributes) -> AccountAttributes:
+    def update_updated_at(self) -> AccountAttributes:
         """Update updated_at field."""
-        # must disable validation to avoid infinite loop
-        obj.model_config["validate_assignment"] = False
-
-        # update updated_at field
-        obj.updated_at = datetime.datetime.now(ZoneInfo("UTC"))
-
-        # enable validation again
-        obj.model_config["validate_assignment"] = True
-        return obj
+        self.updated_at = datetime.datetime.now(ZoneInfo("UTC"))
+        return self
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, AccountAttributes):
@@ -312,19 +303,18 @@ class Settings(BaseSettings):
         return accounts
 
     @model_validator(mode="after")
-    @classmethod
-    def check_unique_account_names(cls, obj: Settings) -> Settings:
+    def check_unique_account_names(self) -> Settings:
         account_names = set()
-        for email in obj.emails:
+        for email in self.emails:
             if email.account_name in account_names:
                 raise ValueError(f"Duplicate account name {email.account_name}")
             account_names.add(email.account_name)
-        for provider in obj.providers:
+        for provider in self.providers:
             if provider.account_name in account_names:
                 raise ValueError(f"Duplicate account name {provider.account_name}")
             account_names.add(provider.account_name)
 
-        return obj
+        return self
 
     @classmethod
     def settings_customise_sources(

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import binascii
 import email.utils
 import mimetypes
 import re
@@ -53,6 +55,153 @@ def _validate_flags(flags: list[str]) -> str:
     return "(" + " ".join(flags) + ")"
 
 
+def encode_mailbox_name(mailbox: str) -> str:
+    """Encode an IMAP mailbox name using RFC 3501 Modified UTF-7."""
+    result: list[str] = []
+    buffer: list[str] = []
+
+    def flush_buffer() -> None:
+        if not buffer:
+            return
+        text = "".join(buffer)
+        encoded = base64.b64encode(text.encode("utf-16-be")).decode("ascii")
+        result.append("&" + encoded.rstrip("=").replace("/", ",") + "-")
+        buffer.clear()
+
+    for char in mailbox:
+        codepoint = ord(char)
+        if char == "&":
+            flush_buffer()
+            result.append("&-")
+        elif 0x20 <= codepoint <= 0x7E:
+            flush_buffer()
+            result.append(char)
+        else:
+            buffer.append(char)
+
+    flush_buffer()
+    return "".join(result)
+
+
+def decode_mailbox_name(mailbox: str) -> str:
+    """Decode an IMAP mailbox name from RFC 3501 Modified UTF-7."""
+    result: list[str] = []
+    index = 0
+
+    while index < len(mailbox):
+        char = mailbox[index]
+        if char != "&":
+            result.append(char)
+            index += 1
+            continue
+
+        end = mailbox.find("-", index + 1)
+        if end == -1:
+            result.append(mailbox[index:])
+            break
+        if end == index + 1:
+            result.append("&")
+            index = end + 1
+            continue
+
+        encoded = mailbox[index + 1 : end].replace(",", "/")
+        padding = "=" * (-len(encoded) % 4)
+        try:
+            decoded = base64.b64decode(encoded + padding, validate=True).decode("utf-16-be")
+        except (binascii.Error, UnicodeDecodeError):
+            result.append(mailbox[index : end + 1])
+        else:
+            result.append(decoded)
+        index = end + 1
+
+    return "".join(result)
+
+
+def _skip_imap_whitespace(value: str, start: int) -> int:
+    """Return the next non-whitespace index in an IMAP response line."""
+    index = start
+    while index < len(value) and value[index].isspace():
+        index += 1
+    return index
+
+
+def _read_quoted_imap_token(value: str, start: int) -> tuple[str, int]:
+    """Read a quoted IMAP token."""
+    index = start + 1
+    token: list[str] = []
+    while index < len(value):
+        char = value[index]
+        if char == "\\" and index + 1 < len(value):
+            token.append(value[index + 1])
+            index += 2
+            continue
+        if char == '"':
+            return "".join(token), index + 1
+        token.append(char)
+        index += 1
+    return "".join(token), index
+
+
+def _read_parenthesized_imap_token(value: str, start: int) -> tuple[str, int]:
+    """Read a parenthesized IMAP token."""
+    depth = 1
+    index = start + 1
+    token: list[str] = []
+    while index < len(value):
+        char = value[index]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return "".join(token), index + 1
+        token.append(char)
+        index += 1
+    return "".join(token), index
+
+
+def _read_atom_imap_token(value: str, start: int) -> tuple[str, int]:
+    """Read an atom IMAP token."""
+    index = start
+    while index < len(value) and not value[index].isspace():
+        index += 1
+    return value[start:index], index
+
+
+def _read_imap_list_token(value: str, start: int) -> tuple[str | None, int]:
+    """Read one token from an IMAP LIST response line."""
+    index = _skip_imap_whitespace(value, start)
+    if index >= len(value):
+        return None, index
+    if value[index] == '"':
+        return _read_quoted_imap_token(value, index)
+    if value[index] == "(":
+        return _read_parenthesized_imap_token(value, index)
+    return _read_atom_imap_token(value, index)
+
+
+def _parse_list_response(item: bytes | str) -> MailboxInfo | None:
+    """Parse one IMAP LIST response into a MailboxInfo object."""
+    item_str = item.decode("utf-8", errors="replace") if isinstance(item, bytes) else str(item)
+    item_str = item_str.strip()
+    if not item_str:
+        return None
+
+    flags: list[str] = []
+    position = 0
+    if item_str.startswith("("):
+        flags_token, position = _read_imap_list_token(item_str, position)
+        flags = [flag.strip() for flag in (flags_token or "").split() if flag.strip()]
+
+    delimiter_token, position = _read_imap_list_token(item_str, position)
+    mailbox_token, _position = _read_imap_list_token(item_str, position)
+    if delimiter_token is None or mailbox_token is None:
+        return None
+
+    delimiter = "" if delimiter_token.upper() == "NIL" else delimiter_token
+    return MailboxInfo(name=decode_mailbox_name(mailbox_token), delimiter=delimiter, flags=flags)
+
+
 def _quote_mailbox(mailbox: str) -> str:
     """Quote mailbox name for IMAP compatibility.
 
@@ -61,13 +210,17 @@ def _quote_mailbox(mailbox: str) -> str:
 
     Per RFC 3501 Section 9 (Formal Syntax), quoted strings must escape
     backslashes and double-quote characters with a preceding backslash.
+    Mailbox names with non-ASCII characters are encoded using Modified UTF-7
+    as required by RFC 3501 Section 5.1.3.
 
     See: https://github.com/ai-zerolab/mcp-email-server/issues/87
+    See: https://github.com/ai-zerolab/mcp-email-server/issues/172
     See: https://www.rfc-editor.org/rfc/rfc3501#section-9
     """
+    encoded = encode_mailbox_name(mailbox)
     # Per RFC 3501, literal double-quote characters in a quoted string must
     # be escaped with a backslash. Backslashes themselves must also be escaped.
-    escaped = mailbox.replace("\\", "\\\\").replace('"', r"\"")
+    escaped = encoded.replace("\\", "\\\\").replace('"', r"\"")
     return f'"{escaped}"'
 
 
@@ -141,10 +294,13 @@ async def _send_imap_id(imap: aioimaplib.IMAP4 | aioimaplib.IMAP4_SSL) -> None:
         if response.result != "OK":
             # Fallback for strict servers (e.g., 163.com)
             # Send raw command with correct parenthesis format
+            new_tag = imap.protocol.new_tag()
+            if hasattr(new_tag, "__await__"):
+                new_tag = await new_tag
             await imap.protocol.execute(
                 aioimaplib.Command(
                     "ID",
-                    imap.protocol.new_tag(),
+                    new_tag,
                     '("name" "mcp-email-server" "version" "1.0.0")',
                 )
             )
@@ -1080,17 +1236,10 @@ class EmailClient:
 
             # Search for folder with \Sent flag
             for folder in folders:
-                folder_str = folder.decode("utf-8") if isinstance(folder, bytes) else str(folder)
-                # IMAP LIST response format: (flags) "delimiter" "name"
-                # Example: (\Sent \HasNoChildren) "/" "Gesendete Objekte"
-                if r"\Sent" in folder_str or "\\Sent" in folder_str:
-                    # Extract folder name from the response
-                    # Split by quotes and get the last quoted part
-                    parts = folder_str.split('"')
-                    if len(parts) >= 3:
-                        folder_name = parts[-2]  # The folder name is the second-to-last quoted part
-                        logger.info(f"Found Sent folder by \\Sent flag: '{folder_name}'")
-                        return folder_name
+                mailbox = _parse_list_response(folder)
+                if mailbox and r"\Sent" in mailbox.flags:
+                    logger.info(f"Found Sent folder by \\Sent flag: '{mailbox.name}'")
+                    return mailbox.name
         except Exception as e:
             logger.debug(f"Error finding Sent folder by flag: {e}")
 
@@ -1359,24 +1508,15 @@ class EmailClient:
             await _send_imap_id(imap)
 
             quoted_ref = _quote_mailbox(reference) if reference else '""'
-            response = await imap.list(quoted_ref, pattern)
+            quoted_pattern = _quote_mailbox(pattern)
+            response = await imap.list(quoted_ref, quoted_pattern)
             _raise_for_imap_error(response, f"LIST mailboxes with pattern {pattern}")
             _, data = response
 
             for item in data:
-                if item == b"":
-                    continue
-                item_str = item.decode("utf-8") if isinstance(item, bytes) else str(item)
-                flags = []
-                if "(" in item_str and ")" in item_str:
-                    flags_str = item_str[item_str.index("(") + 1 : item_str.index(")")]
-                    flags = [f.strip() for f in flags_str.split() if f.strip()]
-
-                parts = item_str.split('"')
-                if len(parts) >= 3:
-                    delimiter = parts[1]
-                    folder_name = parts[-2]
-                    mailboxes.append(MailboxInfo(name=folder_name, delimiter=delimiter, flags=flags))
+                mailbox = _parse_list_response(item)
+                if mailbox:
+                    mailboxes.append(mailbox)
         finally:
             try:
                 await imap.logout()

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -372,6 +372,25 @@ class TestEmailClient:
                     mock_fetch_headers.assert_called_once_with(mock_imap, ["3", "2", "1"])
 
     @pytest.mark.asyncio
+    async def test_get_emails_metadata_encodes_unicode_mailbox(self, email_client):
+        """Unicode mailbox names should be encoded before IMAP SELECT."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b""]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            total, emails = await email_client.get_emails_metadata(mailbox="Entwürfe")
+
+        assert total == 0
+        assert emails == []
+        mock_imap.select.assert_called_once_with('"Entw&APw-rfe"')
+
+    @pytest.mark.asyncio
     async def test_get_emails_metadata_falls_back_to_uid_order_when_dates_missing(self, email_client):
         """Metadata listing should still return emails when INTERNALDATE parsing fails."""
         mock_imap = AsyncMock()

--- a/tests/test_move_and_list_mailboxes.py
+++ b/tests/test_move_and_list_mailboxes.py
@@ -89,6 +89,20 @@ class TestEmailClientMoveEmails:
     """Tests for the low-level EmailClient.move_emails method."""
 
     @pytest.mark.asyncio
+    async def test_move_emails_encodes_unicode_mailboxes(self, email_client):
+        """Unicode mailbox names should be encoded before IMAP SELECT and COPY."""
+        mock_imap = _make_mock_imap()
+        del mock_imap.move
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            moved_ids, failed_ids = await email_client.move_emails(["100"], "Entwürfe", "Gelöschte Elemente")
+
+        assert moved_ids == ["100"]
+        assert failed_ids == []
+        mock_imap.select.assert_called_once_with('"Entw&APw-rfe"')
+        assert mock_imap.uid.call_args_list[0].args == ("copy", "100", '"Gel&APY-schte Elemente"')
+
+    @pytest.mark.asyncio
     async def test_move_emails_copy_delete_fallback(self, email_client):
         """When MOVE capability is absent, should use COPY + STORE \\Deleted + EXPUNGE."""
         mock_imap = _make_mock_imap()
@@ -341,7 +355,7 @@ class TestEmailClientListMailboxes:
         assert result[3].name == "Trash"
 
         # Verify IMAP list was called with correct args
-        mock_imap.list.assert_called_once_with('""', "*")
+        mock_imap.list.assert_called_once_with('""', '"*"')
         mock_imap.logout.assert_called_once()
 
     @pytest.mark.asyncio
@@ -390,6 +404,60 @@ class TestEmailClientListMailboxes:
         assert result[1].name == "Sent"
 
     @pytest.mark.asyncio
+    async def test_list_mailboxes_decodes_exchange_modified_utf7_and_atoms(self, email_client):
+        """Exchange LIST responses with localized folder names should parse correctly."""
+        mock_imap = _make_mock_imap()
+        mock_imap.list = AsyncMock(
+            return_value=(
+                "OK",
+                [
+                    b'(\\HasChildren) "/" Posteingang',
+                    b'(\\Drafts \\HasNoChildren) "/" Entw&APw-rfe',
+                    b'(\\Trash \\HasNoChildren) "/" "Gel&APY-schte Elemente"',
+                ],
+            )
+        )
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.list_mailboxes()
+
+        assert len(result) == 3
+        assert result[0].name == "Posteingang"
+        assert result[0].delimiter == "/"
+        assert result[0].flags == ["\\HasChildren"]
+        assert result[1].name == "Entwürfe"
+        assert result[1].flags == ["\\Drafts", "\\HasNoChildren"]
+        assert result[2].name == "Gelöschte Elemente"
+        assert result[2].flags == ["\\Trash", "\\HasNoChildren"]
+
+    @pytest.mark.asyncio
+    async def test_list_mailboxes_with_nil_delimiter(self, email_client):
+        """NIL hierarchy delimiters should be exposed as an empty string."""
+        mock_imap = _make_mock_imap()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\Noselect) NIL ""']))
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.list_mailboxes()
+
+        assert len(result) == 1
+        assert result[0].name == ""
+        assert result[0].delimiter == ""
+        assert result[0].flags == ["\\Noselect"]
+
+    @pytest.mark.asyncio
+    async def test_list_mailboxes_with_escaped_quoted_name(self, email_client):
+        """Quoted mailbox strings may contain escaped characters."""
+        mock_imap = _make_mock_imap()
+        mock_imap.list = AsyncMock(return_value=("OK", [b'(\\HasNoChildren) "/" "Project \\"A\\""']))
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.list_mailboxes()
+
+        assert len(result) == 1
+        assert result[0].name == 'Project "A"'
+        assert result[0].delimiter == "/"
+
+    @pytest.mark.asyncio
     async def test_list_mailboxes_with_pattern(self, email_client):
         """A custom pattern should be passed through to IMAP LIST."""
         mock_imap = _make_mock_imap()
@@ -406,7 +474,31 @@ class TestEmailClientListMailboxes:
             result = await email_client.list_mailboxes(pattern="INBOX.*")
 
         assert len(result) == 1
-        mock_imap.list.assert_called_once_with('""', "INBOX.*")
+        mock_imap.list.assert_called_once_with('""', '"INBOX.*"')
+
+    @pytest.mark.asyncio
+    async def test_list_mailboxes_quotes_encoded_pattern_with_spaces(self, email_client):
+        """Exact localized mailbox patterns should be encoded and quoted."""
+        mock_imap = _make_mock_imap()
+        mock_imap.list = AsyncMock(return_value=("OK", []))
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.list_mailboxes(pattern="Gelöschte Elemente")
+
+        assert result == []
+        mock_imap.list.assert_called_once_with('""', '"Gel&APY-schte Elemente"')
+
+    @pytest.mark.asyncio
+    async def test_list_mailboxes_quotes_encoded_pattern_preserving_wildcards(self, email_client):
+        """Wildcard patterns should remain wildcard patterns after quoting."""
+        mock_imap = _make_mock_imap()
+        mock_imap.list = AsyncMock(return_value=("OK", []))
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            result = await email_client.list_mailboxes(pattern="Gelöschte *")
+
+        assert result == []
+        mock_imap.list.assert_called_once_with('""', '"Gel&APY-schte *"')
 
     @pytest.mark.asyncio
     async def test_list_mailboxes_with_reference(self, email_client):
@@ -418,7 +510,7 @@ class TestEmailClientListMailboxes:
             result = await email_client.list_mailboxes(reference="INBOX")
 
         assert result == []
-        mock_imap.list.assert_called_once_with('"INBOX"', "*")
+        mock_imap.list.assert_called_once_with('"INBOX"', '"*"')
 
     @pytest.mark.asyncio
     async def test_list_mailboxes_empty_response(self, email_client):

--- a/tests/test_quote_mailbox.py
+++ b/tests/test_quote_mailbox.py
@@ -1,6 +1,6 @@
-"""Tests for the _quote_mailbox helper function."""
+"""Tests for IMAP mailbox encoding and quoting helpers."""
 
-from mcp_email_server.emails.classic import _quote_mailbox
+from mcp_email_server.emails.classic import _quote_mailbox, decode_mailbox_name, encode_mailbox_name
 
 
 class TestQuoteMailbox:
@@ -43,3 +43,31 @@ class TestQuoteMailbox:
         # Per RFC 3501, we should always escape and quote
         # '"INBOX"' should become '"\\"INBOX\\""' (quotes escaped)
         assert _quote_mailbox('"INBOX"') == r'"\"INBOX\""'
+
+
+class TestModifiedUtf7MailboxCodec:
+    """Tests for RFC 3501 Modified UTF-7 mailbox codec."""
+
+    def test_decodes_exchange_german_folder_names(self):
+        """Exchange localized folder names should decode to Unicode."""
+        assert decode_mailbox_name("Entw&APw-rfe") == "Entwürfe"
+        assert decode_mailbox_name("Gel&APY-schte Elemente") == "Gelöschte Elemente"
+
+    def test_encodes_exchange_german_folder_names(self):
+        """Unicode folder names should encode to IMAP wire names."""
+        assert encode_mailbox_name("Entwürfe") == "Entw&APw-rfe"
+        assert encode_mailbox_name("Gelöschte Elemente") == "Gel&APY-schte Elemente"
+
+    def test_ampersand_round_trips(self):
+        """Literal ampersands use the special &- sequence."""
+        assert decode_mailbox_name("Sales &- Support") == "Sales & Support"
+        assert encode_mailbox_name("Sales & Support") == "Sales &- Support"
+
+    def test_invalid_modified_utf7_sequence_is_preserved(self):
+        """Malformed encoded runs should remain visible to callers."""
+        assert decode_mailbox_name("Broken&NotBase64-") == "Broken&NotBase64-"
+
+    def test_quote_mailbox_encodes_unicode_folder_name(self):
+        """Quoted mailbox arguments should use Modified UTF-7 on the wire."""
+        assert _quote_mailbox("Entwürfe") == '"Entw&APw-rfe"'
+        assert _quote_mailbox("Gelöschte Elemente") == '"Gel&APY-schte Elemente"'

--- a/tests/test_save_to_mailbox.py
+++ b/tests/test_save_to_mailbox.py
@@ -257,6 +257,18 @@ class TestAppendToMailbox:
         mock_imap.append.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_append_encodes_unicode_mailbox(self, email_client, incoming_server, mock_imap):
+        msg = MIMEText("body")
+        with patch("mcp_email_server.emails.classic.aioimaplib") as mock_lib:
+            mock_lib.IMAP4_SSL.return_value = mock_imap
+            result = await email_client.append_to_mailbox(msg, incoming_server, "Entwürfe")
+
+        assert result == "unknown"
+        mock_imap.select.assert_called_with('"Entw&APw-rfe"')
+        _, kwargs = mock_imap.append.call_args
+        assert kwargs["mailbox"] == '"Entw&APw-rfe"'
+
+    @pytest.mark.asyncio
     async def test_append_returns_uid_from_appenduid(self, email_client, incoming_server, mock_imap):
         mock_imap.append = AsyncMock(return_value=("OK", [b"[APPENDUID 1234567890 42] APPEND completed"]))
         msg = MIMEText("body")

--- a/tests/test_save_to_sent.py
+++ b/tests/test_save_to_sent.py
@@ -507,6 +507,20 @@ class TestFindSentFolderByFlag:
         assert result == "[Gmail]/Gesendet"
 
     @pytest.mark.asyncio
+    async def test_find_sent_folder_by_flag_decodes_modified_utf7(self, email_client):
+        """Sent folder detection should return decoded Unicode folder names."""
+        mock = AsyncMock()
+        mock.list = AsyncMock(
+            return_value=(
+                "OK",
+                [b'(\\Sent \\HasNoChildren) "/" "Gesendete &ANw-bjekte"'],
+            )
+        )
+
+        result = await email_client._find_sent_folder_by_flag(mock)
+        assert result == "Gesendete Übjekte"
+
+    @pytest.mark.asyncio
     async def test_find_sent_folder_by_flag_not_found(self, email_client, mock_imap_without_sent_flag):
         """Test when no folder with \\Sent flag exists."""
         result = await email_client._find_sent_folder_by_flag(mock_imap_without_sent_flag)


### PR DESCRIPTION
Closes #172

Add RFC 3501 Modified UTF-7 encoding and decoding for IMAP mailbox names, parse LIST responses with quoted and atom folder names, and update mailbox command quoting for localized folders.

Also updates Pydantic validators and IMAP ID fallback handling so the test suite runs without warnings.

Assisted-by: YAAI <261597362+yaai-bot@users.noreply.github.com>
