### PR TITLE
feat: add extract_verification_code tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,18 @@ await send_email(
 
 The `in_reply_to` parameter sets the `In-Reply-To` header, and `references` sets the `References` header. Both are used by email clients to thread conversations properly.
 
+### Extracting Verification Codes
+
+To pull a one-time passcode / verification code out of an email (for example, to complete an automated sign-up or login flow), use the `extract_verification_code` tool. It runs a deterministic regex (no LLM call) over the email body and subject:
+
+```python
+result = await extract_verification_code(account_name="work", email_id="123")
+if result.found:
+    print(result.code)  # e.g. "654321"
+```
+
+The extractor is keyword-guided across English, Chinese, Japanese and Korean (`verification code`, `OTP`, `passcode`, and their localized equivalents) and rejects 4-digit years and `YYYYMMDD` dates to avoid false positives. It returns `found=False` with `code=None` when no code is present.
+
 ## Development
 
 This project is managed using [uv](https://github.com/ai-zerolab/uv).

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -12,11 +12,13 @@ from mcp_email_server.config import (
     get_settings,
 )
 from mcp_email_server.emails.dispatcher import dispatch_handler
+from mcp_email_server.emails.extract import extract_code
 from mcp_email_server.emails.models import (
     AttachmentDownloadResponse,
     EmailContentBatchResponse,
     EmailMetadataPageResponse,
     MailboxInfo,
+    VerificationCodeResponse,
 )
 
 ToolVisibilityPredicate = Callable[[], bool]
@@ -161,6 +163,33 @@ async def get_emails_content(
 ) -> EmailContentBatchResponse:
     handler = dispatch_handler(account_name)
     return await handler.get_emails_content(email_ids, mailbox, mark_as_read)
+
+
+@mcp.tool(
+    description="Extract a verification/OTP code from a specific email. Uses a deterministic regex "
+    "(no LLM call), supports English/Chinese/Japanese/Korean, and rejects years and dates to avoid "
+    "false positives. Use list_emails_metadata first to get the email_id."
+)
+async def extract_verification_code(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    email_id: Annotated[
+        str, Field(description="The email_id to extract the code from (obtained from list_emails_metadata).")
+    ],
+    mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to read the email from.")] = "INBOX",
+) -> VerificationCodeResponse:
+    handler = dispatch_handler(account_name)
+    batch = await handler.get_emails_content([email_id], mailbox)
+    if not batch.emails:
+        return VerificationCodeResponse(email_id=email_id, code=None, found=False)
+    email = batch.emails[0]
+    code = extract_code(email.body) or extract_code(email.subject)
+    return VerificationCodeResponse(
+        email_id=email.email_id,
+        code=code,
+        found=code is not None,
+        sender=email.sender,
+        subject=email.subject,
+    )
 
 
 @mcp.tool(

--- a/mcp_email_server/emails/extract.py
+++ b/mcp_email_server/emails/extract.py
@@ -1,0 +1,62 @@
+"""Regex-based verification/OTP code extraction (dependency-free).
+
+Kept in its own module so it can power the ``extract_verification_code`` MCP
+tool and be unit-tested in isolation. Uses only the standard library.
+"""
+
+import re
+
+# Full-width colon (U+FF1A) is common in CJK emails. Defined via an escape so the
+# source stays free of a character that is visually confusable with the ASCII colon.
+_FW_COLON = "\uff1a"
+
+# At least one explicit delimiter must follow the code keyword before the code
+# itself: an ASCII or full-width colon, the word "is", or a common CJK particle.
+# A mandatory delimiter prevents "verification code Your email" from capturing
+# "Your" as an alphanumeric code.
+_DELIM = rf"\s*(?:[:{_FW_COLON}]|\bis\b|是|为|です)[\s:{_FW_COLON}]*"
+
+# Keyword groups that precede a verification code.
+_CN_JA_KO_KW = r"验证码|认证码|确认码|認証コード|인증\s*코드|코드"
+_EN_KW = r"verification\s*code|confirm(?:ation)?\s*code|security\s*code|passcode|OTP|pin\s*code"
+_ALL_KW = rf"{_CN_JA_KO_KW}|{_EN_KW}"
+
+# Keyword-guided patterns, numeric preferred then alphanumeric.
+_KEYWORD_PATTERNS = [
+    re.compile(rf"\bcode{_DELIM}(\d{{4,12}})\b", re.IGNORECASE),
+    re.compile(rf"(?:{_ALL_KW}){_DELIM}(\d{{4,12}})\b", re.IGNORECASE),
+    re.compile(rf"\bcode{_DELIM}([A-Za-z0-9]{{4,12}})\b", re.IGNORECASE),
+    re.compile(rf"(?:{_ALL_KW}){_DELIM}([A-Za-z0-9]{{4,12}})\b", re.IGNORECASE),
+]
+
+# Fallback: a standalone digit run when no keyword-guided match is found.
+_STANDALONE_PATTERN = re.compile(r"(?:^|\s)(\d{4,12})(?:\s|$|\.|,)", re.MULTILINE)
+
+
+def _looks_like_date(digits: str) -> bool:
+    """Return True if ``digits`` looks like a year (1900-2099) or a YYYYMMDD date."""
+    if len(digits) == 4:
+        return 1900 <= int(digits) <= 2099
+    if len(digits) == 8:
+        year, month, day = int(digits[:4]), int(digits[4:6]), int(digits[6:8])
+        return 1900 <= year <= 2099 and 1 <= month <= 12 and 1 <= day <= 31
+    return False
+
+
+def extract_code(text: str) -> str | None:
+    """Extract a verification/OTP code (4-12 chars) from ``text``.
+
+    Prefers a code that follows an explicit keyword (``verification code``,
+    ``OTP``, ``passcode`` and their Chinese / Japanese / Korean equivalents) with
+    a mandatory delimiter. Falls back to a standalone 4-12 digit run, rejecting
+    plausible years and ``YYYYMMDD`` dates to limit false positives. Returns
+    ``None`` when nothing matches.
+    """
+    for pattern in _KEYWORD_PATTERNS:
+        match = pattern.search(text)
+        if match and not _looks_like_date(match.group(1)):
+            return match.group(1)
+    standalone = _STANDALONE_PATTERN.search(text)
+    if standalone and not _looks_like_date(standalone.group(1)):
+        return standalone.group(1)
+    return None

--- a/mcp_email_server/emails/models.py
+++ b/mcp_email_server/emails/models.py
@@ -71,3 +71,13 @@ class AttachmentDownloadResponse(BaseModel):
     mime_type: str
     size: int
     saved_path: str
+
+
+class VerificationCodeResponse(BaseModel):
+    """Verification/OTP code extracted from a single email"""
+
+    email_id: str
+    code: str | None
+    found: bool
+    sender: str | None = None
+    subject: str | None = None

--- a/tests/test_extract_code.py
+++ b/tests/test_extract_code.py
@@ -1,0 +1,134 @@
+# Test fixtures intentionally use full-width CJK punctuation (e.g. a full-width
+# colon between the keyword and the code) to mirror real verification emails,
+# so silence the ambiguous-character lint for this file.
+# ruff: noqa: RUF001
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_email_server.app import extract_verification_code
+from mcp_email_server.emails.extract import extract_code
+from mcp_email_server.emails.models import EmailBodyResponse, EmailContentBatchResponse
+
+
+class TestExtractCode:
+    def test_english(self):
+        assert extract_code("Your verification code is 654321") == "654321"
+        assert extract_code("confirmation code: 998877") == "998877"
+        assert extract_code("Your OTP: 7890") == "7890"
+        assert extract_code("passcode: 5678") == "5678"
+
+    def test_chinese(self):
+        assert extract_code("您的验证码：123456") == "123456"
+        assert extract_code("确认码：ABCD12") == "ABCD12"
+        # dual-delimiter case
+        assert extract_code("您好，您的验证码是：654321。请勿泄露。") == "654321"
+        assert extract_code("您的验证码为：987654") == "987654"
+
+    def test_japanese_korean(self):
+        assert extract_code("認証コード：345678") == "345678"
+        assert extract_code("인증 코드: 456789") == "456789"
+        assert extract_code("認証コードは 456789 です") == "456789"
+
+    def test_code_is_pattern(self):
+        assert extract_code("Your code is 112233") == "112233"
+        assert extract_code("code: ABCDEF") == "ABCDEF"
+
+    def test_standalone_digits(self):
+        assert extract_code("Please enter 5678 to verify") == "5678"
+        assert extract_code(" 12345678 ") == "12345678"
+
+    def test_no_code(self):
+        assert extract_code("Hello, this is a regular email") is None
+        assert extract_code("") is None
+        assert extract_code("Short 12") is None
+
+    def test_does_not_capture_word_after_label(self):
+        assert extract_code("verification code Your email is ready") is None
+        assert extract_code("Your verification code Your code is 824593. Valid for 10 minutes.") == "824593"
+        assert extract_code("verification code is 987654") == "987654"
+
+    def test_rejects_years(self):
+        assert extract_code("Order Confirmation #ABC-12345 sent on 2026-04-11") is None
+        assert extract_code("Thanks for joining us in 2024!") is None
+        assert extract_code("Subject mentions code 2026 year") is None
+
+    def test_rejects_yyyymmdd_dates(self):
+        assert extract_code("QA LANG JA 20260411") is None
+        assert extract_code("reference 20260101 please") is None
+
+    def test_five_to_seven_digits_in_year_range_still_extracted(self):
+        assert extract_code("code is 12345") == "12345"
+        assert extract_code("code is 123456") == "123456"
+
+
+def _batch(body: str, subject: str = "Login") -> EmailContentBatchResponse:
+    return EmailContentBatchResponse(
+        emails=[
+            EmailBodyResponse(
+                email_id="123",
+                subject=subject,
+                sender="noreply@example.com",
+                recipients=["me@example.com"],
+                date=datetime.now(timezone.utc),
+                body=body,
+                attachments=[],
+            )
+        ],
+        requested_count=1,
+        retrieved_count=1,
+        failed_ids=[],
+    )
+
+
+class TestExtractVerificationCodeTool:
+    @pytest.mark.asyncio
+    async def test_extracts_from_body(self):
+        mock_handler = AsyncMock()
+        mock_handler.get_emails_content.return_value = _batch("Your verification code is 654321")
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await extract_verification_code(account_name="work", email_id="123")
+
+        assert result.found is True
+        assert result.code == "654321"
+        assert result.email_id == "123"
+        assert result.sender == "noreply@example.com"
+        mock_handler.get_emails_content.assert_called_once_with(["123"], "INBOX")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_subject(self):
+        mock_handler = AsyncMock()
+        mock_handler.get_emails_content.return_value = _batch("Nothing useful here.", subject="Your code: 778899")
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await extract_verification_code(account_name="work", email_id="123")
+
+        assert result.found is True
+        assert result.code == "778899"
+
+    @pytest.mark.asyncio
+    async def test_no_code_found(self):
+        mock_handler = AsyncMock()
+        mock_handler.get_emails_content.return_value = _batch("Just a regular newsletter.", subject="Hello")
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await extract_verification_code(account_name="work", email_id="123")
+
+        assert result.found is False
+        assert result.code is None
+
+    @pytest.mark.asyncio
+    async def test_email_not_found(self):
+        mock_handler = AsyncMock()
+        mock_handler.get_emails_content.return_value = EmailContentBatchResponse(
+            emails=[], requested_count=1, retrieved_count=0, failed_ids=["123"]
+        )
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await extract_verification_code(account_name="work", email_id="123", mailbox="Spam")
+
+        assert result.found is False
+        assert result.code is None
+        mock_handler.get_emails_content.assert_called_once_with(["123"], "Spam")


### PR DESCRIPTION
## Summary

Agents that automate sign-up / login flows constantly need to read a one-time passcode (OTP / verification code) back out of an email. Today the only option is to fetch the full body via `get_emails_content` and ask the LLM to "find the code", which wastes tokens and is unreliable — order numbers, prices, years (`2026`) and `YYYYMMDD` dates are routinely mis-read as the code.

This PR adds a small, **dependency-free, deterministic** tool that returns the code directly.

## What's included

- **`extract_verification_code(account_name, email_id, mailbox="INBOX")`** — reuses the existing `get_emails_content` path, runs a regex extractor over the body then the subject, and returns `VerificationCodeResponse{email_id, code, found, sender, subject}`.
- **New `mcp_email_server/emails/extract.py`** — standard-library only (`re`):
  - Keyword-guided across English, Chinese, Japanese and Korean (`verification code`, `OTP`, `passcode`, and their localized equivalents) with a mandatory delimiter, so "verification code Your email" does not capture "Your".
  - Falls back to a standalone 4-12 digit run only when no keyword match is found.
  - Rejects 4-digit years (1900-2099) and 8-digit `YYYYMMDD` dates to limit false positives.
- **`VerificationCodeResponse`** model.
- **Tests** (`tests/test_extract_code.py`) covering the extractor (English / Chinese / Japanese / Korean, dual delimiters, standalone codes, year/date rejection) and the tool (body hit, subject fallback, no code, email not found).
- **README** usage section.

## Notes

- No new dependencies (`deptry` clean); `make check` and `make test` pass locally (327 tests).
- I scoped this PR to a single focused tool. If you would prefer a broader `extract_data` tool (order / shipping / receipt / calendar / code) sharing the same module, I have that ready as a follow-up — happy to go either way.
