### PR TITLE
fix: omit CHARSET in UID SEARCH so Exchange IMAP works

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -815,8 +815,12 @@ class EmailClient:
             )
             logger.info(f"Get metadata: Search criteria: {search_criteria}")
 
-            # Search for messages - use UID SEARCH for better compatibility
-            _, messages = await imap.uid_search(*search_criteria)
+            # Search for messages - use UID SEARCH for better compatibility.
+            # charset=None: aioimaplib defaults to "CHARSET utf-8", which Microsoft
+            # Exchange rejects with `NO [BADCHARSET (US-ASCII)] The specified charset
+            # is not supported.`, breaking all search/list operations. Omitting the
+            # CHARSET token works on Exchange and is harmless on other servers.
+            _, messages = await imap.uid_search(*search_criteria, charset=None)
 
             # Handle empty or None responses
             if not messages or not messages[0]:

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -391,6 +391,29 @@ class TestEmailClient:
         mock_imap.select.assert_called_once_with('"Entw&APw-rfe"')
 
     @pytest.mark.asyncio
+    async def test_get_emails_metadata_search_omits_charset(self, email_client):
+        """UID SEARCH must not send 'CHARSET utf-8'.
+
+        aioimaplib defaults to charset='utf-8'; Microsoft Exchange rejects that
+        with `NO [BADCHARSET (US-ASCII)]`, breaking all search/list operations.
+        We must pass charset=None so no CHARSET token is sent.
+        """
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b""]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            await email_client.get_emails_metadata(mailbox="INBOX")
+
+        mock_imap.uid_search.assert_called_once()
+        assert mock_imap.uid_search.call_args.kwargs.get("charset") is None
+
+    @pytest.mark.asyncio
     async def test_get_emails_metadata_falls_back_to_uid_order_when_dates_missing(self, email_client):
         """Metadata listing should still return emails when INTERNALDATE parsing fails."""
         mock_imap = AsyncMock()


### PR DESCRIPTION
## Problem

`get_emails_metadata` runs `await imap.uid_search(*search_criteria)`. `aioimaplib.uid_search` defaults to `charset='utf-8'`, so the wire command is:

```
UID SEARCH CHARSET utf-8 ALL
```

Microsoft Exchange's IMAP server does not support a UTF-8 SEARCH charset and rejects this with:

```
NO [BADCHARSET (US-ASCII)] The specified charset is not supported.
```

The result is that **every** search/list operation fails against Exchange mailboxes — `get_emails`, paging, filtering by date/subject/sender, etc. I hit this on a production Exchange 2016/2019 server (French locale) where listing the inbox returned nothing usable until I traced it to the SEARCH charset.

This is long-standing, documented Exchange behaviour (e.g. emersion/go-imap#48) and per RFC 3501 `US-ASCII` is the only charset a server must support for SEARCH.

## Fix

Pass `charset=None` to `uid_search`, so no `CHARSET` token is sent:

```
UID SEARCH ALL
```

Exchange accepts this, and it's equally valid on every other IMAP server (Gmail, Dovecot, ProtonMail Bridge, etc.) — the search criteria currently built are all ASCII atoms, so nothing is lost.

## Testing

- Added `test_get_emails_metadata_search_omits_charset`, which asserts `uid_search` is called with `charset=None`.
- Full suite green locally: `314 passed`.
- `ruff check` clean.
- Verified end-to-end against a live Exchange IMAPS server: search returned the full mailbox after the change, whereas before it returned `BADCHARSET`.