### PR TITLE
feat: add global sender allowlist for list_emails_metadata and get_emails_content

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                   | `true`        | No       |
 | `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)       | -             | No       |
 | `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all     | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all  | -             | No       |
 
 ### Read-only IMAP mode
 
@@ -222,6 +223,37 @@ MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS="alice@example.com,bob@example.com"
 When configured, any To/CC/BCC address not on the list is rejected with a clear error. Matching is
 case-insensitive and understands the `Name <addr@example.com>` form. The `list_allowed_recipients`
 tool appears only when an allowlist is configured, so default installs keep a minimal tool surface.
+
+### Filtering Incoming Mail (Sender Allowlist)
+
+By default all senders are visible. Set `allowed_senders` to show mail only from trusted senders.
+Patterns support globs (e.g. `*@company.com`) and exact addresses, matched case-insensitively. Leave
+it empty (the default) to show everything.
+
+```toml
+allowed_senders = ["*@company.com", "alice@example.com"]
+```
+
+Or via environment variable (comma-separated):
+
+```
+MCP_EMAIL_SERVER_ALLOWED_SENDERS="*@company.com,alice@example.com"
+```
+
+When configured, filtering is applied in the read path: `list_emails_metadata` excludes non-allowed
+senders **before** pagination, so `total` and page sizes reflect only allowed mail; `get_emails_content`
+and `download_attachment` check the sender before reading a message, so a non-allowed message's body and
+attachments are never fetched or marked read, and it is reported as inaccessible — indistinguishable from
+a missing message. The `list_allowed_senders` tool appears only when an allowlist is configured.
+
+**Scope:** the allowlist protects read paths only (`list_emails_metadata`, `get_emails_content`,
+`download_attachment`). UID-based mutation tools (`delete_emails`, `mark_emails_as_read`, `move_emails`,
+`archive_emails`) are not yet filtered and can still act on any UID; enforcing the allowlist on those is
+planned as a follow-up.
+
+**Note:** matching is against the message's `From` header — local filtering only, not sender
+authentication. A spoofed `From` will pass the allowlist, so this is not a substitute for provider-side
+SPF / DKIM / DMARC enforcement.
 
 ### Self-Signed Certificates and IMAP STARTTLS (e.g., ProtonMail Bridge)
 

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -33,6 +33,10 @@ def _has_allowed_recipients() -> bool:
     return bool(get_settings().allowed_recipients)
 
 
+def _has_allowed_senders() -> bool:
+    return bool(get_settings().allowed_senders)
+
+
 def _enforce_recipient_allowlist(
     recipients: list[str],
     cc: list[str] | None,
@@ -216,6 +220,17 @@ async def get_emails_content(
 )
 async def list_allowed_recipients() -> list[str]:
     return get_settings().allowed_recipients
+
+
+@mcp.tool(
+    description=(
+        "List the configured inbound sender allowlist — the address patterns whose mail is visible "
+        "via list_emails_metadata and get_emails_content. Only available when an allowlist is configured."
+    ),
+    visible_if=_has_allowed_senders,
+)
+async def list_allowed_senders() -> list[str]:
+    return get_settings().allowed_senders
 
 
 @mcp.tool(

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import fnmatch
 import os
 from collections.abc import Iterable
 from email.utils import parseaddr
@@ -39,9 +40,29 @@ def normalize_address(raw: str) -> str:
     return addr.strip().lower()
 
 
+def sender_allowed(sender: str, patterns: list[str]) -> bool:
+    """Return True if the sender's address matches any allowlist pattern (or the list is empty).
+
+    The bare address is extracted via normalize_address (handles "Name <addr>") and lowercased,
+    then matched against the lowercased glob patterns with fnmatchcase. An empty allowlist allows
+    everyone; an unparseable sender never matches a non-empty allowlist (blocked, safe default).
+    """
+    if not patterns:
+        return True
+    addr = normalize_address(sender)
+    if not addr:
+        return False
+    return any(fnmatch.fnmatchcase(addr, pattern.lower()) for pattern in patterns)
+
+
 def _normalize_address_list(raw: Iterable[str]) -> list[str]:
     """Normalize each address, drop empties, de-duplicate (order-preserving)."""
     return list(dict.fromkeys(a for a in (normalize_address(x) for x in raw) if a))
+
+
+def _normalize_pattern_list(raw: Iterable[str]) -> list[str]:
+    """Lowercase, strip, de-duplicate (order-preserving). Glob characters are preserved."""
+    return list(dict.fromkeys(p.strip().lower() for p in raw if p.strip()))
 
 
 CONFIG_PATH = Path(os.getenv("MCP_EMAIL_SERVER_CONFIG_PATH", DEFAULT_CONFIG_PATH)).expanduser().resolve()
@@ -257,6 +278,7 @@ class Settings(BaseSettings):
     db_location: str = CONFIG_PATH.with_name("db.sqlite3").as_posix()
     enable_attachment_download: bool = False
     allowed_recipients: list[str] = []
+    allowed_senders: list[str] = []
 
     model_config = SettingsConfigDict(toml_file=CONFIG_PATH, validate_assignment=True, revalidate_instances="always")
 
@@ -278,6 +300,15 @@ class Settings(BaseSettings):
         env_allowed = os.getenv("MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS")
         if env_allowed is not None:
             self.allowed_recipients = _normalize_address_list(env_allowed.split(","))
+
+        # Normalise allowed_senders from TOML (lowercased, de-duplicated; globs preserved)
+        if self.allowed_senders:
+            self.allowed_senders = _normalize_pattern_list(self.allowed_senders)
+
+        # Environment variable overrides TOML (comma-separated); an empty string clears the allowlist.
+        env_senders = os.getenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS")
+        if env_senders is not None:
+            self.allowed_senders = _normalize_pattern_list(env_senders.split(","))
 
         # Check for email configuration from environment variables
         env_email = EmailSettings.from_env()

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -4,7 +4,7 @@ import datetime
 import fnmatch
 import os
 from collections.abc import Iterable
-from email.utils import parseaddr
+from email.utils import getaddresses, parseaddr
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -41,18 +41,19 @@ def normalize_address(raw: str) -> str:
 
 
 def sender_allowed(sender: str, patterns: list[str]) -> bool:
-    """Return True if the sender's address matches any allowlist pattern (or the list is empty).
+    """Return True if exactly one sender address matches any allowlist pattern.
 
-    The bare address is extracted via normalize_address (handles "Name <addr>") and lowercased,
-    then matched against the lowercased glob patterns with fnmatchcase. An empty allowlist allows
-    everyone; an unparseable sender never matches a non-empty allowlist (blocked, safe default).
+    An empty allowlist allows everyone. When an allowlist is configured, malformed, empty, or
+    multi-address From headers fail closed rather than relying on parser leniency.
     """
     if not patterns:
         return True
-    addr = normalize_address(sender)
-    if not addr:
+
+    addrs = [addr.strip().lower() for _name, addr in getaddresses([sender]) if addr.strip()]
+    if len(addrs) != 1:
         return False
-    return any(fnmatch.fnmatchcase(addr, pattern.lower()) for pattern in patterns)
+
+    return any(fnmatch.fnmatchcase(addrs[0], pattern.lower()) for pattern in patterns)
 
 
 def _normalize_address_list(raw: Iterable[str]) -> list[str]:

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -21,7 +21,7 @@ import aioimaplib
 import aiosmtplib
 from bs4 import BeautifulSoup
 
-from mcp_email_server.config import EmailServer, EmailSettings
+from mcp_email_server.config import EmailServer, EmailSettings, get_settings, sender_allowed
 from mcp_email_server.emails import EmailHandler
 from mcp_email_server.emails.models import (
     AttachmentDownloadResponse,
@@ -804,6 +804,59 @@ class EmailClient:
 
         return results
 
+    async def _batch_fetch_senders(
+        self,
+        imap: aioimaplib.IMAP4_SSL | aioimaplib.IMAP4,
+        email_ids: list[bytes] | list[str],
+        chunk_size: int = 500,
+    ) -> dict[str, str]:
+        """Batch fetch the From header for all UIDs (chunked, sequential), for allowlist filtering.
+
+        Returns {uid: raw From header}. Fetches only HEADER.FIELDS (FROM) to stay light and reuses
+        _parse_headers (which tolerates a From-only header block).
+        """
+        if not email_ids:
+            return {}
+
+        chunks = [email_ids[i : i + chunk_size] for i in range(0, len(email_ids), chunk_size)]
+        senders: dict[str, str] = {}
+        for chunk in chunks:
+            str_ids = [uid.decode() if isinstance(uid, bytes) else uid for uid in chunk]
+            uid_list = ",".join(str_ids)
+            _, data = await imap.uid("fetch", uid_list, "BODY.PEEK[HEADER.FIELDS (FROM)]")
+            for i, item in enumerate(data):
+                if not isinstance(item, bytes) or b"BODY[HEADER" not in item:
+                    continue
+                uid_match = re.search(rb"UID (\d+)", item)
+                if uid_match and i + 1 < len(data) and isinstance(data[i + 1], bytearray):
+                    meta = self._parse_headers(uid_match.group(1).decode(), bytes(data[i + 1]))
+                    if meta:
+                        senders[meta["email_id"]] = meta["from"]
+                elif i + 2 < len(data) and isinstance(data[i + 1], bytearray):
+                    uid_after = re.search(rb"UID (\d+)", data[i + 2]) if isinstance(data[i + 2], bytes) else None
+                    if uid_after:
+                        meta = self._parse_headers(uid_after.group(1).decode(), bytes(data[i + 1]))
+                        if meta:
+                            senders[meta["email_id"]] = meta["from"]
+        return senders
+
+    async def _enforce_sender_allowlist(
+        self,
+        imap: aioimaplib.IMAP4_SSL | aioimaplib.IMAP4,
+        email_id: str,
+        allowed_senders: list[str] | None,
+    ) -> None:
+        """Raise ValueError (identical to not-found) when sender is not on the allowlist.
+
+        No-op when ``allowed_senders`` is empty or None (backwards-compatible).
+        """
+        if allowed_senders:
+            uid_senders = await self._batch_fetch_senders(imap, [email_id])
+            if not sender_allowed(uid_senders.get(email_id, ""), allowed_senders):
+                msg = f"Failed to fetch email with UID {email_id}"
+                logger.error(msg)
+                raise ValueError(msg)
+
     async def get_emails_metadata(
         self,
         page: int = 1,
@@ -821,6 +874,7 @@ class EmailClient:
         body: str | None = None,
         text: str | None = None,
         has_attachment: bool | None = None,
+        allowed_senders: list[str] | None = None,
     ) -> tuple[int, list[dict[str, Any]]]:
         imap = await self._connect_imap()
         try:
@@ -859,6 +913,16 @@ class EmailClient:
 
             email_ids = messages[0].split()
             logger.info(f"Found {len(email_ids)} email IDs")
+
+            # Sender allowlist: filter candidates BEFORE sorting/pagination so total + pages stay honest.
+            if allowed_senders:
+                uid_senders = await self._batch_fetch_senders(imap, email_ids)
+                email_ids = [
+                    uid for uid in email_ids if sender_allowed(uid_senders.get(uid.decode(), ""), allowed_senders)
+                ]
+                logger.info(f"Sender allowlist active: {len(email_ids)} of {len(uid_senders)} match")
+                if not email_ids:
+                    return 0, []
 
             # Phase 1: Batch fetch INTERNALDATE for sorting (sequential chunks)
             fetch_dates_start = time.perf_counter()
@@ -968,7 +1032,11 @@ class EmailClient:
         return None
 
     async def get_email_body_by_id(
-        self, email_id: str, mailbox: str = "INBOX", mark_as_read: bool = False
+        self,
+        email_id: str,
+        mailbox: str = "INBOX",
+        mark_as_read: bool = False,
+        allowed_senders: list[str] | None = None,
     ) -> dict[str, Any] | None:
         imap = await self._connect_imap()
         try:
@@ -977,6 +1045,14 @@ class EmailClient:
             await _send_imap_id(imap)
             select_response = await imap.select(_quote_mailbox(mailbox))
             _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
+
+            # Sender allowlist: check the From header BEFORE reading the body, so a blocked
+            # message is never fetched/parsed, never marked read, and is indistinguishable from
+            # a missing/inaccessible one (caller sees None either way).
+            if allowed_senders:
+                uid_senders = await self._batch_fetch_senders(imap, [email_id])
+                if not sender_allowed(uid_senders.get(email_id, ""), allowed_senders):
+                    return None
 
             # Fetch the specific email by UID without implicitly marking it as read
             data = await self._fetch_email_with_formats(imap, email_id)
@@ -1019,6 +1095,7 @@ class EmailClient:
         attachment_name: str,
         save_path: str,
         mailbox: str = "INBOX",
+        allowed_senders: list[str] | None = None,
     ) -> dict[str, Any]:
         """Download a specific attachment from an email and save it to disk.
 
@@ -1027,6 +1104,8 @@ class EmailClient:
             attachment_name: The filename of the attachment to download.
             save_path: The local path where the attachment will be saved.
             mailbox: The mailbox to search in (default: "INBOX").
+            allowed_senders: Optional sender allowlist; when set, a non-allowed sender's
+                message is treated as not found and its body is never fetched.
 
         Returns:
             A dictionary with download result information.
@@ -1037,6 +1116,11 @@ class EmailClient:
             await _send_imap_id(imap)
             select_response = await imap.select(_quote_mailbox(mailbox))
             _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
+
+            # Read-path allowlist: check the From header before fetching the body, so a
+            # blocked sender's message is never read. Blocked fails identically to a missing
+            # UID (same ValueError below), so it does not reveal whether the message exists.
+            await self._enforce_sender_allowlist(imap, email_id, allowed_senders)
 
             data = await self._fetch_email_with_formats(imap, email_id)
             if not data:
@@ -1609,6 +1693,7 @@ class ClassicEmailHandler(EmailHandler):
             body,
             text,
             has_attachment,
+            allowed_senders=get_settings().allowed_senders,
         )
         emails = [EmailMetadata.from_email(d) for d in email_dicts]
         return EmailMetadataPageResponse(
@@ -1624,28 +1709,36 @@ class ClassicEmailHandler(EmailHandler):
     async def get_emails_content(
         self, email_ids: list[str], mailbox: str = "INBOX", mark_as_read: bool = False
     ) -> EmailContentBatchResponse:
-        """Batch retrieve email body content"""
+        """Batch retrieve email body content, honoring the sender allowlist.
+
+        The allowlist is enforced in the read path: get_email_body_by_id checks the From header
+        before fetching the body, so a blocked message is never read or marked and returns None —
+        indistinguishable from a missing/inaccessible one (both land in failed_ids).
+        """
+        allowed_senders = get_settings().allowed_senders
         emails = []
         failed_ids = []
 
         for email_id in email_ids:
             try:
-                email_data = await self.incoming_client.get_email_body_by_id(email_id, mailbox, mark_as_read)
-                if email_data:
-                    emails.append(
-                        EmailBodyResponse(
-                            email_id=email_data["email_id"],
-                            message_id=email_data.get("message_id"),
-                            subject=email_data["subject"],
-                            sender=email_data["from"],
-                            recipients=email_data["to"],
-                            date=email_data["date"],
-                            body=email_data["body"],
-                            attachments=email_data["attachments"],
-                        )
-                    )
-                else:
+                email_data = await self.incoming_client.get_email_body_by_id(
+                    email_id, mailbox, mark_as_read, allowed_senders=allowed_senders
+                )
+                if not email_data:
                     failed_ids.append(email_id)
+                    continue
+                emails.append(
+                    EmailBodyResponse(
+                        email_id=email_data["email_id"],
+                        message_id=email_data.get("message_id"),
+                        subject=email_data["subject"],
+                        sender=email_data["from"],
+                        recipients=email_data["to"],
+                        date=email_data["date"],
+                        body=email_data["body"],
+                        attachments=email_data["attachments"],
+                    )
+                )
             except Exception as e:
                 logger.error(f"Failed to retrieve email {email_id}: {e}")
                 failed_ids.append(email_id)
@@ -1807,7 +1900,10 @@ class ClassicEmailHandler(EmailHandler):
         Returns:
             AttachmentDownloadResponse with download result information.
         """
-        result = await self.incoming_client.download_attachment(email_id, attachment_name, save_path, mailbox)
+        allowed_senders = get_settings().allowed_senders
+        result = await self.incoming_client.download_attachment(
+            email_id, attachment_name, save_path, mailbox, allowed_senders=allowed_senders
+        )
         return AttachmentDownloadResponse(
             email_id=result["email_id"],
             attachment_name=result["attachment_name"],

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from email.message import EmailMessage
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -95,51 +95,53 @@ class TestClassicEmailHandler:
         mock_get_metadata = AsyncMock(return_value=(1, [email_data]))
 
         # Apply the mock
-        with patch.object(classic_handler.incoming_client, "get_emails_metadata", mock_get_metadata):
-            # Call the method
-            result = await classic_handler.get_emails_metadata(
-                page=1,
-                page_size=10,
-                before=now,
-                since=None,
-                subject="Test",
-                from_address="sender@example.com",
-                to_address=None,
-            )
+        with patch("mcp_email_server.emails.classic.get_settings", return_value=MagicMock(allowed_senders=[])):
+            with patch.object(classic_handler.incoming_client, "get_emails_metadata", mock_get_metadata):
+                # Call the method
+                result = await classic_handler.get_emails_metadata(
+                    page=1,
+                    page_size=10,
+                    before=now,
+                    since=None,
+                    subject="Test",
+                    from_address="sender@example.com",
+                    to_address=None,
+                )
 
-            # Verify the result
-            assert isinstance(result, EmailMetadataPageResponse)
-            assert result.page == 1
-            assert result.page_size == 10
-            assert result.before == now
-            assert result.since is None
-            assert result.subject == "Test"
-            assert len(result.emails) == 1
-            assert isinstance(result.emails[0], EmailMetadata)
-            assert result.emails[0].subject == "Test Subject"
-            assert result.emails[0].sender == "sender@example.com"
-            assert result.emails[0].date == now
-            assert result.emails[0].attachments == []
-            assert result.total == 1
+                # Verify the result
+                assert isinstance(result, EmailMetadataPageResponse)
+                assert result.page == 1
+                assert result.page_size == 10
+                assert result.before == now
+                assert result.since is None
+                assert result.subject == "Test"
+                assert len(result.emails) == 1
+                assert isinstance(result.emails[0], EmailMetadata)
+                assert result.emails[0].subject == "Test Subject"
+                assert result.emails[0].sender == "sender@example.com"
+                assert result.emails[0].date == now
+                assert result.emails[0].attachments == []
+                assert result.total == 1
 
-            # Verify the client method was called correctly
-            mock_get_metadata.assert_called_once_with(
-                1,
-                10,
-                now,
-                None,
-                "Test",
-                "sender@example.com",
-                None,
-                "desc",
-                "INBOX",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+                # Verify the client method was called correctly
+                mock_get_metadata.assert_called_once_with(
+                    1,
+                    10,
+                    now,
+                    None,
+                    "Test",
+                    "sender@example.com",
+                    None,
+                    "desc",
+                    "INBOX",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    allowed_senders=[],
+                )
 
     @pytest.mark.asyncio
     async def test_get_emails_with_mailbox(self, classic_handler):
@@ -156,20 +158,36 @@ class TestClassicEmailHandler:
 
         mock_get_metadata = AsyncMock(return_value=(1, [email_data]))
 
-        with patch.object(classic_handler.incoming_client, "get_emails_metadata", mock_get_metadata):
-            result = await classic_handler.get_emails_metadata(
-                page=1,
-                page_size=10,
-                mailbox="Sent",
-            )
+        with patch("mcp_email_server.emails.classic.get_settings", return_value=MagicMock(allowed_senders=[])):
+            with patch.object(classic_handler.incoming_client, "get_emails_metadata", mock_get_metadata):
+                result = await classic_handler.get_emails_metadata(
+                    page=1,
+                    page_size=10,
+                    mailbox="Sent",
+                )
 
-            assert isinstance(result, EmailMetadataPageResponse)
-            assert len(result.emails) == 1
+                assert isinstance(result, EmailMetadataPageResponse)
+                assert len(result.emails) == 1
 
-            # Verify mailbox parameter was passed correctly
-            mock_get_metadata.assert_called_once_with(
-                1, 10, None, None, None, None, None, "desc", "Sent", None, None, None, None, None, None
-            )
+                # Verify mailbox parameter was passed correctly
+                mock_get_metadata.assert_called_once_with(
+                    1,
+                    10,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "desc",
+                    "Sent",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    allowed_senders=[],
+                )
 
     @pytest.mark.asyncio
     async def test_send_email(self, classic_handler):
@@ -403,7 +421,7 @@ class TestClassicEmailHandler:
             assert result.size == 1024
             assert result.saved_path == save_path
 
-            mock_download.assert_called_once_with("123", "document.pdf", save_path, "INBOX")
+            mock_download.assert_called_once_with("123", "document.pdf", save_path, "INBOX", allowed_senders=[])
 
     @pytest.mark.asyncio
     async def test_send_email_with_reply_headers(self, classic_handler):
@@ -484,7 +502,7 @@ class TestClassicEmailHandler:
             assert result.emails[0].body == "Test email body"
 
             # Verify the client method was called correctly
-            mock_get_body.assert_called_once_with("123", "INBOX", False)
+            mock_get_body.assert_called_once_with("123", "INBOX", False, allowed_senders=[])
 
     @pytest.mark.asyncio
     async def test_get_emails_content_mark_as_read_true(self, classic_handler):
@@ -511,7 +529,7 @@ class TestClassicEmailHandler:
             )
 
             assert len(result.emails) == 1
-            mock_get_body.assert_called_once_with("123", "INBOX", True)
+            mock_get_body.assert_called_once_with("123", "INBOX", True, allowed_senders=[])
 
     @pytest.mark.asyncio
     async def test_get_emails_content_mark_as_read_default_false(self, classic_handler):
@@ -533,7 +551,82 @@ class TestClassicEmailHandler:
         with patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get_body):
             await classic_handler.get_emails_content(email_ids=["456"])
 
-            mock_get_body.assert_called_once_with("456", "INBOX", False)
+            mock_get_body.assert_called_once_with("456", "INBOX", False, allowed_senders=[])
+
+    @pytest.mark.asyncio
+    async def test_get_emails_metadata_passes_allowlist_to_client(self, classic_handler):
+        mock_get = AsyncMock(return_value=(0, []))
+        with patch(
+            "mcp_email_server.emails.classic.get_settings", return_value=MagicMock(allowed_senders=["*@example.com"])
+        ):
+            with patch.object(classic_handler.incoming_client, "get_emails_metadata", mock_get):
+                await classic_handler.get_emails_metadata(page=1, page_size=10)
+        assert mock_get.call_args.kwargs.get("allowed_senders") == ["*@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_download_attachment_passes_allowlist_to_client(self, classic_handler):
+        mock_dl = AsyncMock(
+            return_value={
+                "email_id": "1",
+                "attachment_name": "a.png",
+                "mime_type": "image/png",
+                "size": 3,
+                "saved_path": "/tmp/a.png",  # noqa: S108
+            }
+        )
+        with patch(
+            "mcp_email_server.emails.classic.get_settings",
+            return_value=MagicMock(allowed_senders=["*@example.com"]),
+        ):
+            with patch.object(classic_handler.incoming_client, "download_attachment", mock_dl):
+                await classic_handler.download_attachment("1", "a.png", "/tmp/a.png")  # noqa: S108
+        assert mock_dl.call_args.kwargs.get("allowed_senders") == ["*@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_passes_allowed_senders_to_client(self, classic_handler):
+        """The handler forwards the configured allowlist to the read path, which enforces it."""
+        now = datetime.now(timezone.utc)
+        email_data = {
+            "email_id": "1",
+            "message_id": None,
+            "subject": "a",
+            "from": "alice@example.com",
+            "to": [],
+            "date": now,
+            "body": "x",
+            "attachments": [],
+        }
+        mock_get = AsyncMock(return_value=email_data)
+        with patch(
+            "mcp_email_server.emails.classic.get_settings",
+            return_value=MagicMock(allowed_senders=["*@example.com"]),
+        ):
+            with patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get):
+                await classic_handler.get_emails_content(["1"])
+        assert mock_get.call_args.kwargs.get("allowed_senders") == ["*@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_no_allowlist_passes_mark_through(self, classic_handler):
+        now = datetime.now(timezone.utc)
+        alice = {
+            "email_id": "1",
+            "message_id": None,
+            "subject": "a",
+            "from": "alice@example.com",
+            "to": [],
+            "date": now,
+            "body": "x",
+            "attachments": [],
+        }
+        mock_get = AsyncMock(return_value=alice)
+        mock_mark = AsyncMock()
+        with patch("mcp_email_server.emails.classic.get_settings", return_value=MagicMock(allowed_senders=[])):
+            with patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get):
+                with patch.object(classic_handler.incoming_client, "mark_emails_as_read", mock_mark):
+                    result = await classic_handler.get_emails_content(["1"], mark_as_read=True)
+        assert result.retrieved_count == 1
+        assert mock_get.call_args.args[2] is True  # mark passed through to fetch
+        mock_mark.assert_not_called()  # no deferred batch-mark when not filtering
 
 
 class TestEmailClientGetEmailBodyById:
@@ -611,6 +704,41 @@ class TestEmailClientGetEmailBodyById:
         assert result is not None
         assert result["email_id"] == "123"
         assert mock_imap.uid.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_email_body_by_id_blocked_sender_returns_none_without_reading_body(self, email_client, mock_imap):
+        """A blocked sender returns None and the body is never fetched (From is checked first)."""
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_senders", return_value={"123": "bob@evil.com"}):
+                with patch.object(email_client, "_fetch_email_with_formats", new=AsyncMock()) as mock_body:
+                    result = await email_client.get_email_body_by_id("123", allowed_senders=["alice@example.com"])
+
+        assert result is None
+        mock_body.assert_not_called()  # blocked body is never read or parsed
+
+    @pytest.mark.asyncio
+    async def test_get_email_body_by_id_allowed_sender_reads_body(self, email_client, mock_imap):
+        """An allowed sender passes the From check and the body is fetched."""
+        mock_imap.uid = AsyncMock(return_value=("OK", [b"FETCH BODY[]", bytearray(self._raw_email())]))
+
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_senders", return_value={"123": "sender@example.com"}):
+                result = await email_client.get_email_body_by_id("123", allowed_senders=["*@example.com"])
+
+        assert result is not None
+        assert result["email_id"] == "123"
+
+    @pytest.mark.asyncio
+    async def test_get_email_body_by_id_no_allowlist_skips_sender_check(self, email_client, mock_imap):
+        """With no allowlist configured, the From header is not pre-fetched (zero overhead)."""
+        mock_imap.uid = AsyncMock(return_value=("OK", [b"FETCH BODY[]", bytearray(self._raw_email())]))
+
+        with patch.object(email_client, "_imap_connect", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_senders") as mock_senders:
+                result = await email_client.get_email_body_by_id("123")
+
+        assert result is not None
+        mock_senders.assert_not_called()
 
 
 class TestEmailClientMarkAsRead:
@@ -808,3 +936,47 @@ Subject: No Date Email
         assert "100" in result
         assert result["100"]["subject"] == "Test"
         assert result["100"]["from"] == "sender@example.com"
+
+
+class TestGetEmailsContentEdgeCases:
+    @pytest.mark.asyncio
+    async def test_none_email_data_goes_to_failed_ids(self, classic_handler):
+        """A fetch that returns None is reported as a genuine failure."""
+        mock_get = AsyncMock(return_value=None)
+        with patch("mcp_email_server.emails.classic.get_settings", return_value=MagicMock(allowed_senders=[])):
+            with patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get):
+                result = await classic_handler.get_emails_content(["1"])
+        assert result.emails == []
+        assert result.failed_ids == ["1"]
+        assert result.retrieved_count == 0
+
+    @pytest.mark.asyncio
+    async def test_fetch_exception_goes_to_failed_ids(self, classic_handler):
+        """An exception during fetch is caught and reported as a failure, not raised."""
+        mock_get = AsyncMock(side_effect=Exception("boom"))
+        with patch("mcp_email_server.emails.classic.get_settings", return_value=MagicMock(allowed_senders=[])):
+            with patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get):
+                result = await classic_handler.get_emails_content(["1"])
+        assert result.failed_ids == ["1"]
+        assert result.retrieved_count == 0
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_passes_mark_as_read(self, classic_handler):
+        """mark_as_read is forwarded to the read path (which marks only allowed messages)."""
+        now = datetime.now(timezone.utc)
+        email_data = {
+            "email_id": "1",
+            "message_id": None,
+            "subject": "a",
+            "from": "alice@example.com",
+            "to": [],
+            "date": now,
+            "body": "x",
+            "attachments": [],
+        }
+        mock_get = AsyncMock(return_value=email_data)
+        with patch("mcp_email_server.emails.classic.get_settings", return_value=MagicMock(allowed_senders=[])):
+            with patch.object(classic_handler.incoming_client, "get_email_body_by_id", mock_get):
+                result = await classic_handler.get_emails_content(["1"], mark_as_read=True)
+        assert result.retrieved_count == 1
+        assert mock_get.call_args.args == ("1", "INBOX", True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -157,9 +157,10 @@ def test_config():
         ("alice@example.com", ["*@other.com", "alice@example.com"], True),  # matches second pattern
         ("", ["*@example.com"], False),  # empty sender => blocked
         ("not an email", ["*@example.com"], False),  # unparseable => blocked
-        # multi-address From: parseaddr takes the first address, so a blocked sender
-        # cannot smuggle through by appending an allowed one => blocked
+        # Multi-address From headers fail closed regardless of address order.
         ("blocked@evil.com, alice@example.com", ["alice@example.com"], False),
+        ("alice@example.com, blocked@evil.com", ["alice@example.com"], False),
+        ("Alice <alice@example.com>, Mallory <blocked@evil.com>", ["alice@example.com"], False),
         ("alice@example.com", ["*@Example.com"], True),  # mixed-case pattern still matches
     ],
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from mcp_email_server.config import (
     ProviderSettings,
     get_settings,
     normalize_address,
+    sender_allowed,
     store_settings,
 )
 
@@ -144,6 +145,28 @@ def test_config():
         )
 
 
+@pytest.mark.parametrize(
+    ("sender", "patterns", "expected"),
+    [
+        ("alice@example.com", [], True),  # empty allowlist => all allowed
+        ("alice@example.com", ["alice@example.com"], True),  # exact
+        ("Alice <Alice@Example.com>", ["alice@example.com"], True),  # display name + case-insensitive
+        ("bob@example.com", ["*@example.com"], True),  # domain glob
+        ("bob@other.com", ["*@example.com"], False),  # domain glob, no match
+        ("mallory@evil.com", ["alice@example.com"], False),  # no match
+        ("alice@example.com", ["*@other.com", "alice@example.com"], True),  # matches second pattern
+        ("", ["*@example.com"], False),  # empty sender => blocked
+        ("not an email", ["*@example.com"], False),  # unparseable => blocked
+        # multi-address From: parseaddr takes the first address, so a blocked sender
+        # cannot smuggle through by appending an allowed one => blocked
+        ("blocked@evil.com, alice@example.com", ["alice@example.com"], False),
+        ("alice@example.com", ["*@Example.com"], True),  # mixed-case pattern still matches
+    ],
+)
+def test_sender_allowed(sender, patterns, expected):
+    assert sender_allowed(sender, patterns) is expected
+
+
 def test_allowed_recipients_defaults_to_empty(tmp_path, monkeypatch):
     import mcp_email_server.config as config_module
     from mcp_email_server.config import Settings
@@ -171,5 +194,37 @@ def test_allowed_recipients_toml_normalised(tmp_path, monkeypatch):
     config_module._settings = None
     try:
         assert config_module.get_settings(reload=True).allowed_recipients == ["alice@example.com", "bob@example.com"]
+    finally:
+        config_module._settings = None
+
+
+def test_allowed_senders_defaults_to_empty(tmp_path, monkeypatch):
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    blank = tmp_path / "config.toml"
+    blank.write_text("")
+    monkeypatch.setitem(Settings.model_config, "toml_file", blank)
+    config_module._settings = None
+    try:
+        assert config_module.get_settings(reload=True).allowed_senders == []
+    finally:
+        config_module._settings = None
+
+
+def test_allowed_senders_toml_normalised_preserves_globs(tmp_path, monkeypatch):
+    import tomli_w
+
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    toml_data = {"allowed_senders": ["*@Example.COM", "BOB@example.com", "*@example.com"]}
+    cfg = tmp_path / "config.toml"
+    cfg.write_bytes(tomli_w.dumps(toml_data).encode())
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        # lowercased + de-duplicated, but glob characters preserved (NOT run through parseaddr)
+        assert config_module.get_settings(reload=True).allowed_senders == ["*@example.com", "bob@example.com"]
     finally:
         config_module._settings = None

--- a/tests/test_email_attachments.py
+++ b/tests/test_email_attachments.py
@@ -668,3 +668,113 @@ class TestDownloadInlineAttachment:
                         attachment_name="missing.pdf",
                         save_path=str(tmp_path / "missing.pdf"),
                     )
+
+
+class TestDownloadAttachmentSenderAllowlist:
+    """download_attachment must honor the sender allowlist (read-path protection)."""
+
+    @staticmethod
+    def _mock_imap():
+        import asyncio
+
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", [b"1"]))
+        mock_imap.logout = AsyncMock()
+        return mock_imap
+
+    @pytest.mark.asyncio
+    async def test_blocked_sender_never_fetches_body(self, email_client, tmp_path):
+        """A blocked sender's attachment download never reads the full message body."""
+        mock_imap = self._mock_imap()
+        with (
+            patch.object(
+                email_client, "_batch_fetch_senders", AsyncMock(return_value={"1": "evil@blocked.com"})
+            ) as mock_senders,
+            patch.object(email_client, "_fetch_email_with_formats", AsyncMock()) as mock_fetch,
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            with pytest.raises(ValueError, match=re.escape("Failed to fetch email with UID 1")):
+                await email_client.download_attachment(
+                    email_id="1",
+                    attachment_name="out.png",
+                    save_path=str(tmp_path / "out.png"),
+                    allowed_senders=["*@allowed.com"],
+                )
+        mock_senders.assert_awaited_once()
+        mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_blocked_indistinguishable_from_missing(self, email_client, tmp_path):
+        """A blocked-existing UID and a nonexistent UID raise the identical error (no oracle)."""
+        save_path = str(tmp_path / "out.png")
+
+        async def _run(senders):
+            mock_imap = self._mock_imap()
+            with (
+                patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+                patch.object(email_client, "_fetch_email_with_formats", AsyncMock(return_value=None)) as mock_fetch,
+                patch.object(email_client, "imap_class", return_value=mock_imap),
+            ):
+                with pytest.raises(ValueError) as exc:
+                    await email_client.download_attachment(
+                        email_id="1",
+                        attachment_name="out.png",
+                        save_path=save_path,
+                        allowed_senders=["*@allowed.com"],
+                    )
+                mock_fetch.assert_not_called()
+            return str(exc.value)
+
+        blocked_msg = await _run({"1": "evil@blocked.com"})  # exists but blocked
+        missing_msg = await _run({})  # does not exist
+        assert blocked_msg == missing_msg == "Failed to fetch email with UID 1"
+
+    @pytest.mark.asyncio
+    async def test_allowed_sender_downloads(self, email_client, tmp_path):
+        """An allowed sender's attachment is fetched and saved."""
+        raw_email = _build_apple_mail_inline_image(b"\x89PNG\r\n\x1a\ninline")
+        mock_imap = self._mock_imap()
+
+        async def _fake_fetch(_imap, _email_id):
+            return [b"1 FETCH (BODY[] {%d}" % len(raw_email), bytearray(raw_email), b")"]
+
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value={"1": "ok@allowed.com"})),
+            patch.object(email_client, "_fetch_email_with_formats", side_effect=_fake_fetch) as mock_fetch,
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            result = await email_client.download_attachment(
+                email_id="1",
+                attachment_name="ausflug.png",
+                save_path=str(tmp_path / "ausflug.png"),
+                allowed_senders=["*@allowed.com"],
+            )
+        assert result["attachment_name"] == "ausflug.png"
+        mock_fetch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_skips_sender_check(self, email_client, tmp_path):
+        """With no allowlist, download_attachment does no sender fetch (backwards-compatible)."""
+        raw_email = _build_apple_mail_inline_image(b"\x89PNG\r\n\x1a\ninline")
+        mock_imap = self._mock_imap()
+
+        async def _fake_fetch(_imap, _email_id):
+            return [b"1 FETCH (BODY[] {%d}" % len(raw_email), bytearray(raw_email), b")"]
+
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock()) as mock_senders,
+            patch.object(email_client, "_fetch_email_with_formats", side_effect=_fake_fetch),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            result = await email_client.download_attachment(
+                email_id="1",
+                attachment_name="ausflug.png",
+                save_path=str(tmp_path / "ausflug.png"),
+                allowed_senders=[],
+            )
+        assert result["attachment_name"] == "ausflug.png"
+        mock_senders.assert_not_called()

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -1044,3 +1044,273 @@ class TestBatchFetchHeaders:
         assert len(result) == 2
         assert result["100"]["subject"] == "First"
         assert result["200"]["subject"] == "Second"
+
+
+class TestBatchFetchSenders:
+    @pytest.mark.asyncio
+    async def test_batch_fetch_senders(self, email_client):
+        mock_imap = AsyncMock()
+        mock_imap.uid = AsyncMock(
+            return_value=(
+                None,
+                [
+                    b"1 FETCH (UID 100 BODY[HEADER.FIELDS (FROM)] {25}",
+                    bytearray(b"From: alice@example.com\r\n\r\n"),
+                    b")",
+                    b"2 FETCH (UID 101 BODY[HEADER.FIELDS (FROM)] {32}",
+                    bytearray(b"From: Bob <bob@evil.com>\r\n\r\n"),
+                    b")",
+                ],
+            )
+        )
+        result = await email_client._batch_fetch_senders(mock_imap, [b"100", b"101"])
+        assert result == {"100": "alice@example.com", "101": "Bob <bob@evil.com>"}
+
+
+class TestGetEmailsMetadataSenderFilter:
+    @pytest.mark.asyncio
+    async def test_get_emails_metadata_filters_blocked_senders_honest_total(self, email_client):
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b"1 2 3"]))
+        mock_imap.logout = AsyncMock()
+
+        mock_senders = {"1": "alice@example.com", "2": "bob@evil.com", "3": "alice@example.com"}
+        mock_dates = {
+            "1": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "3": datetime(2024, 1, 3, tzinfo=timezone.utc),
+        }
+        mock_metadata = {
+            "3": {
+                "email_id": "3",
+                "subject": "S3",
+                "from": "alice@example.com",
+                "to": [],
+                "date": datetime(2024, 1, 3, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+            "1": {
+                "email_id": "1",
+                "subject": "S1",
+                "from": "alice@example.com",
+                "to": [],
+                "date": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+        }
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_senders", return_value=mock_senders) as mock_fs:
+                with patch.object(email_client, "_batch_fetch_dates", return_value=mock_dates) as mock_fd:
+                    with patch.object(email_client, "_batch_fetch_headers", return_value=mock_metadata):
+                        total, emails = await email_client.get_emails_metadata(
+                            page=1, page_size=10, allowed_senders=["alice@example.com"]
+                        )
+
+        assert total == 2  # honest: allowed count, NOT the raw 3
+        assert len(emails) == 2
+        assert all(e["from"] == "alice@example.com" for e in emails)
+        mock_fs.assert_called_once_with(mock_imap, [b"1", b"2", b"3"])  # senders fetched for ALL matches
+        mock_fd.assert_called_once_with(mock_imap, [b"1", b"3"])  # dates only for allowed
+
+    @pytest.mark.asyncio
+    async def test_get_emails_metadata_full_page_despite_blocked(self, email_client):
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b"1 2 3 4"]))
+        mock_imap.logout = AsyncMock()
+
+        mock_senders = {
+            "1": "alice@example.com",
+            "2": "bob@evil.com",
+            "3": "alice@example.com",
+            "4": "alice@example.com",
+        }
+        mock_dates = {
+            "1": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "3": datetime(2024, 1, 3, tzinfo=timezone.utc),
+            "4": datetime(2024, 1, 4, tzinfo=timezone.utc),
+        }
+        mock_metadata = {
+            "4": {
+                "email_id": "4",
+                "subject": "S4",
+                "from": "alice@example.com",
+                "to": [],
+                "date": datetime(2024, 1, 4, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+            "3": {
+                "email_id": "3",
+                "subject": "S3",
+                "from": "alice@example.com",
+                "to": [],
+                "date": datetime(2024, 1, 3, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+        }
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_senders", return_value=mock_senders):
+                with patch.object(email_client, "_batch_fetch_dates", return_value=mock_dates):
+                    with patch.object(email_client, "_batch_fetch_headers", return_value=mock_metadata):
+                        total, emails = await email_client.get_emails_metadata(
+                            page=1, page_size=2, allowed_senders=["alice@example.com"]
+                        )
+
+        assert total == 3  # 3 allowed (4 matched, 1 blocked)
+        assert len(emails) == 2  # full page, not short
+
+    @pytest.mark.asyncio
+    async def test_get_emails_metadata_no_allowlist_skips_sender_fetch(self, email_client):
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b"1 2 3"]))
+        mock_imap.logout = AsyncMock()
+
+        mock_dates = {
+            "1": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "2": datetime(2024, 1, 2, tzinfo=timezone.utc),
+            "3": datetime(2024, 1, 3, tzinfo=timezone.utc),
+        }
+        mock_metadata = {
+            "3": {
+                "email_id": "3",
+                "subject": "S3",
+                "from": "c@test.com",
+                "to": [],
+                "date": datetime(2024, 1, 3, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+            "2": {
+                "email_id": "2",
+                "subject": "S2",
+                "from": "b@test.com",
+                "to": [],
+                "date": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+            "1": {
+                "email_id": "1",
+                "subject": "S1",
+                "from": "a@test.com",
+                "to": [],
+                "date": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "attachments": [],
+            },
+        }
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_senders") as mock_fs:
+                with patch.object(email_client, "_batch_fetch_dates", return_value=mock_dates):
+                    with patch.object(email_client, "_batch_fetch_headers", return_value=mock_metadata):
+                        total, emails = await email_client.get_emails_metadata(page=1, page_size=10)
+
+        assert total == 3
+        assert len(emails) == 3
+        mock_fs.assert_not_called()  # zero overhead when no allowlist
+
+
+class TestSenderFilterCoverage:
+    @pytest.mark.asyncio
+    async def test_batch_fetch_senders_empty_returns_empty(self, email_client):
+        mock_imap = AsyncMock()
+        result = await email_client._batch_fetch_senders(mock_imap, [])
+        assert result == {}
+        mock_imap.uid.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_senders_skips_unparseable_header(self, email_client):
+        """A header block that fails to parse is skipped, not added."""
+        mock_imap = AsyncMock()
+        mock_imap.uid = AsyncMock(
+            return_value=(
+                None,
+                [b"1 FETCH (UID 100 BODY[HEADER.FIELDS (FROM)] {1}", bytearray(b"x"), b")"],
+            )
+        )
+        with patch.object(email_client, "_parse_headers", return_value=None):
+            result = await email_client._batch_fetch_senders(mock_imap, [b"100"])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_senders_proton_bridge_format(self, email_client):
+        """Proton Bridge returns the UID in a trailing item after the header payload."""
+        mock_imap = AsyncMock()
+        mock_imap.uid = AsyncMock(
+            return_value=(
+                None,
+                [
+                    b"1 FETCH (BODY[HEADER.FIELDS (FROM)] {23}",
+                    bytearray(b"From: bob@example.com\r\n\r\n"),
+                    b" UID 200)",
+                ],
+            )
+        )
+        result = await email_client._batch_fetch_senders(mock_imap, [b"200"])
+        assert result == {"200": "bob@example.com"}
+
+    @pytest.mark.asyncio
+    async def test_get_emails_metadata_all_blocked_returns_empty(self, email_client):
+        """When every match is filtered out, total is 0 and the date fetch is skipped."""
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b"1 2"]))
+        mock_imap.logout = AsyncMock()
+        mock_senders = {"1": "bob@evil.com", "2": "carol@evil.com"}
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(email_client, "_batch_fetch_senders", return_value=mock_senders):
+                with patch.object(email_client, "_batch_fetch_dates") as mock_fd:
+                    total, emails = await email_client.get_emails_metadata(
+                        page=1, page_size=10, allowed_senders=["alice@example.com"]
+                    )
+        assert total == 0
+        assert emails == []
+        mock_fd.assert_not_called()  # early return before the date fetch
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_senders_non_bytearray_payload_skipped(self, email_client):
+        """An item whose payload is not a bytearray matches neither branch and is skipped."""
+        mock_imap = AsyncMock()
+        mock_imap.uid = AsyncMock(
+            return_value=(None, [b"1 FETCH (UID 100 BODY[HEADER.FIELDS (FROM)] {0}", b"not-bytearray", b")"])
+        )
+        result = await email_client._batch_fetch_senders(mock_imap, [b"100"])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_senders_proton_missing_uid_skipped(self, email_client):
+        """A trailing-payload item with no UID is skipped."""
+        mock_imap = AsyncMock()
+        mock_imap.uid = AsyncMock(
+            return_value=(None, [b"1 FETCH (BODY[HEADER.FIELDS (FROM)] {x}", bytearray(b"From: a@b.com\r\n\r\n"), b")"])
+        )
+        result = await email_client._batch_fetch_senders(mock_imap, [b"100"])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_senders_proton_unparseable_skipped(self, email_client):
+        """A trailing-UID item whose header fails to parse is skipped."""
+        mock_imap = AsyncMock()
+        mock_imap.uid = AsyncMock(
+            return_value=(None, [b"1 FETCH (BODY[HEADER.FIELDS (FROM)] {1}", bytearray(b"x"), b" UID 300)"])
+        )
+        with patch.object(email_client, "_parse_headers", return_value=None):
+            result = await email_client._batch_fetch_senders(mock_imap, [b"300"])
+        assert result == {}

--- a/tests/test_env_config_coverage.py
+++ b/tests/test_env_config_coverage.py
@@ -476,3 +476,52 @@ def test_allowed_recipients_empty_env_overrides_toml(tmp_path, monkeypatch):
         assert config_module.get_settings(reload=True).allowed_recipients == []
     finally:
         config_module._settings = None
+
+
+def test_allowed_senders_from_env(tmp_path, monkeypatch):
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    blank = tmp_path / "config.toml"
+    blank.write_text("")
+    monkeypatch.setitem(Settings.model_config, "toml_file", blank)
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS", "*@Example.com, BOB@EXAMPLE.COM , *@example.com")
+    config_module._settings = None
+    try:
+        assert config_module.get_settings(reload=True).allowed_senders == ["*@example.com", "bob@example.com"]
+    finally:
+        config_module._settings = None
+
+
+def test_allowed_senders_env_overrides_toml(tmp_path, monkeypatch):
+    import tomli_w
+
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_bytes(tomli_w.dumps({"allowed_senders": ["fromtoml@example.com"]}).encode())
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS", "*@env.com")
+    config_module._settings = None
+    try:
+        assert config_module.get_settings(reload=True).allowed_senders == ["*@env.com"]
+    finally:
+        config_module._settings = None
+
+
+def test_allowed_senders_empty_env_clears_toml(tmp_path, monkeypatch):
+    import tomli_w
+
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_bytes(tomli_w.dumps({"allowed_senders": ["*@example.com"]}).encode())
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS", "")
+    config_module._settings = None
+    try:
+        assert config_module.get_settings(reload=True).allowed_senders == []
+    finally:
+        config_module._settings = None

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -11,6 +11,7 @@ from mcp_email_server.app import (
     download_attachment,
     get_emails_content,
     list_allowed_recipients,
+    list_allowed_senders,
     list_available_accounts,
     list_emails_metadata,
     list_mailboxes,
@@ -951,3 +952,29 @@ class TestMcpTools:
                         body="B",
                     )
         mock_handler.save_to_mailbox.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_allowed_senders_hidden_when_unconfigured(self):
+        mock_settings = MagicMock()
+        mock_settings.allowed_senders = []
+        mock_settings.get_accounts.return_value = []
+        with patch("mcp_email_server.app.get_settings", return_value=mock_settings):
+            tool_names = {tool.name for tool in await app_module.mcp.list_tools()}
+        assert "list_allowed_senders" not in tool_names
+
+    @pytest.mark.asyncio
+    async def test_list_allowed_senders_visible_when_configured(self):
+        mock_settings = MagicMock()
+        mock_settings.allowed_senders = ["*@example.com"]
+        mock_settings.get_accounts.return_value = []
+        with patch("mcp_email_server.app.get_settings", return_value=mock_settings):
+            tool_names = {tool.name for tool in await app_module.mcp.list_tools()}
+        assert "list_allowed_senders" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_list_allowed_senders_returns_list(self):
+        mock_settings = MagicMock()
+        mock_settings.allowed_senders = ["*@example.com", "bob@example.com"]
+        with patch("mcp_email_server.app.get_settings", return_value=mock_settings):
+            result = await list_allowed_senders()
+        assert result == ["*@example.com", "bob@example.com"]


### PR DESCRIPTION
## Summary

Adds an optional global **sender allowlist** for inbound reads — the inbound counterpart to the recipient allowlist merged in #139. When `allowed_senders` is empty (the default), behavior is unchanged.

- Adds `allowed_senders: list[str] = []` to `Settings` — empty means all senders visible (backwards-compatible)
- Configurable via TOML (`allowed_senders = ["*@company.com", "alice@example.com"]`) or env var (`MCP_EMAIL_SERVER_ALLOWED_SENDERS=*@company.com,alice@example.com`); env overrides TOML
- **Note:** the TOML setting is top-level, not nested in an `[[emails]]` block
- Glob + exact matching, case-insensitive (e.g. `*@company.com` matches any address at that domain)
- Applied across **all inbound read paths** — `list_emails_metadata`, `get_emails_content`, and `download_attachment` — each checks the `From` header before reading
- New `list_allowed_senders` tool, registered only when an allowlist is configured (default tool surface unchanged)
- README updated with an env-var entry and a usage section

## Design pass: honest pagination, `total`, and filtered retrieval

This is the inbound design pass requested when the earlier combined PR was split — *"the sender allowlist affects inbound read semantics and needs its own design pass around pagination, `total`, and filtered retrieval behavior."* Filtering happens **in the read path before pagination**, not after the fact:

- **`list_emails_metadata`** filters senders *before* sorting and the page slice, so `total` reflects the allowed count and a page returns up to `page_size` allowed messages (no short pages). Senders are fetched once (`FROM`-only via `BODY.PEEK[HEADER.FIELDS (FROM)]`, reusing the existing header parser); when no allowlist is configured, no extra IMAP work is done.
- **`get_emails_content`** checks the `From` header *before* reading a message: a blocked sender's body is never fetched or marked `\Seen`, and the message is returned in `failed_ids` — indistinguishable from a missing/inaccessible UID, so the allowlist doesn't disclose whether a hidden message exists.
- **`download_attachment`** applies the same `From`-first check before fetching the raw message: a blocked sender's body/attachments are never fetched or marked read, and a blocked message fails with the **same** error as a missing UID — indistinguishable from not-found.
- Unparseable/missing `From` headers are treated as not-allowed (fail-closed) when an allowlist is active.

## Scope

`allowed_senders` protects **read paths only** (`list_emails_metadata`, `get_emails_content`, `download_attachment`). The UID-based mutation tools (`delete_emails`, `mark_emails_as_read`, `move_emails`, `archive_emails`) still act on any UID passed to them; enforcing the allowlist on those is planned as a focused **follow-up PR** rather than expanding this one.

## A note on authenticity (SPF/DKIM/DMARC)

Matching is done against the message's RFC 5322 `From` header — **local filtering only, not sender authentication**. A spoofed `From` will pass the allowlist, so this is **not** a substitute for provider-side SPF/DKIM/DMARC enforcement.

## Motivation

An MCP-capable assistant with `mcp-email-server` can read mail from any sender — an exposure for spam and prompt-injection via email content. A sender allowlist restricts the assistant's inbound view to trusted senders/domains.

## Test plan

- [x] `allowed_senders = []` → all mail visible; no extra IMAP calls (default, backwards-compatible)
- [x] `list_emails_metadata`: blocked senders excluded; **`total` = allowed count**; full page despite interspersed blocked senders
- [x] `get_emails_content`: a blocked sender's body is never fetched/marked; it's reported in `failed_ids`, indistinguishable from a missing UID
- [x] `download_attachment`: a blocked sender's body is **never fetched** (regression test asserts `_fetch_email_with_formats` is not called); blocked fails with the same error as a missing UID
- [x] Blocked email never marked read; allowed emails still marked when `mark_as_read=True`
- [x] Glob (`*@company.com`), exact, case-insensitive, and `Name <addr>` matching
- [x] Multi-address `From` cannot smuggle a blocked sender past the allowlist (`From: blocked@evil.com, alice@example.com` → blocked)
- [x] Unparseable/missing sender → blocked (fail-closed)
- [x] TOML + env parsing; env overrides TOML; empty env clears; globs preserved
- [x] Full suite green (388 tests); `make check` clean (ruff, prettier, deptry)
- [x] End-to-end tested in Claude Desktop against a live IMAP/SMTP account: `list_emails_metadata` `total` and visible mail track the allowlist (removing a sender drops `total` 2 → 1; the message is hidden but not deleted, and re-allowlisting restores it); a typo in a pattern **fails closed**. Content path: fetching a known-but-now-filtered ID returns `{retrieved_count: 0, failed_ids: [id]}` — identical to a bogus ID (no IDOR, no existence oracle) — and the blocked message stays unread. `list_allowed_senders` reflects the config.

## Note on glob semantics

Patterns use `fnmatch`, so `*` matches across `.` and `@`. `*@company.com` is the canonical domain match; `*.example.com` would match any subdomain — use the most specific pattern that fits.

Closes #142

## Transparency note

Written by [Claude Code](https://claude.com/claude-code) using the Superpowers plugin, following a spec + implementation plan designed collaboratively with the author, with per-task and whole-branch automated review plus a dedicated pre-submission security audit of the inbound read paths. All code reviewed by the author before submission. Commits include `Co-Authored-By: Claude Opus 4.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
