### PR TITLE
feat: enforce sender allowlist on mutation tools (follow-up to #180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,12 @@ Or via environment variable (comma-separated):
 MCP_EMAIL_SERVER_ALLOWED_SENDERS="*@company.com,alice@example.com"
 ```
 
-When configured, filtering is applied in the read path: `list_emails_metadata` excludes non-allowed
-senders **before** pagination, so `total` and page sizes reflect only allowed mail; `get_emails_content`
-and `download_attachment` check the sender before reading a message, so a non-allowed message's body and
-attachments are never fetched or marked read, and it is reported as inaccessible — indistinguishable from
-a missing message. The `list_allowed_senders` tool appears only when an allowlist is configured.
+When configured, filtering is applied to inbound read and mutation paths: `list_emails_metadata` excludes
+non-allowed senders **before** pagination, so `total` and page sizes reflect only allowed mail;
+`get_emails_content` and `download_attachment` check the sender before reading a message, so a non-allowed
+message's body and attachments are never fetched or marked read, and it is reported as inaccessible —
+indistinguishable from a missing message. Mutation tools first check the sender and never delete, flag, or
+move blocked mail. The `list_allowed_senders` tool appears only when an allowlist is configured.
 
 **Scope:** the allowlist protects every inbound path — read (`list_emails_metadata`, `get_emails_content`,
 `download_attachment`) and mutation (`delete_emails`, `mark_emails_as_read`, `move_emails`,

--- a/README.md
+++ b/README.md
@@ -63,28 +63,29 @@ You can also configure the email server using environment variables, which is pa
 
 #### Available Environment Variables
 
-| Variable                                      | Description                                            | Default       | Required |
-| --------------------------------------------- | ------------------------------------------------------ | ------------- | -------- |
-| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                     | `"default"`   | No       |
-| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                           | Email prefix  | No       |
-| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                          | -             | Yes      |
-| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                         | Same as email | No       |
-| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                         | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                       | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                       | `993`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                        | `true`        | No       |
-| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                   | `false`       | No       |
-| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed) | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for read-only mode              | -             | No       |
-| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                       | `465`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                        | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                        | `false`       | No       |
-| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)      | `true`        | No       |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                             | `false`       | No       |
-| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                   | `true`        | No       |
-| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)       | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all     | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all  | -             | No       |
+| Variable                                      | Description                                                  | Default       | Required |
+| --------------------------------------------- | ------------------------------------------------------------ | ------------- | -------- |
+| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                           | `"default"`   | No       |
+| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                 | Email prefix  | No       |
+| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                | -             | Yes      |
+| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                               | Same as email | No       |
+| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                               | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                             | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                             | `993`         | No       |
+| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                              | `true`        | No       |
+| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                         | `false`       | No       |
+| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)       | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for read-only mode                    | -             | No       |
+| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                             | `465`         | No       |
+| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                              | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                              | `false`       | No       |
+| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)            | `true`        | No       |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                   | `false`       | No       |
+| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                         | `true`        | No       |
+| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)             | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all           | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all        | -             | No       |
+| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op) | `false`       | No       |
 
 ### Read-only IMAP mode
 
@@ -246,10 +247,16 @@ and `download_attachment` check the sender before reading a message, so a non-al
 attachments are never fetched or marked read, and it is reported as inaccessible — indistinguishable from
 a missing message. The `list_allowed_senders` tool appears only when an allowlist is configured.
 
-**Scope:** the allowlist protects read paths only (`list_emails_metadata`, `get_emails_content`,
-`download_attachment`). UID-based mutation tools (`delete_emails`, `mark_emails_as_read`, `move_emails`,
-`archive_emails`) are not yet filtered and can still act on any UID; enforcing the allowlist on those is
-planned as a follow-up.
+**Scope:** the allowlist protects every inbound path — read (`list_emails_metadata`, `get_emails_content`,
+`download_attachment`) and mutation (`delete_emails`, `mark_emails_as_read`, `move_emails`,
+`archive_emails`). A blocked sender's mail is never read, deleted, flagged, or moved.
+
+**Blocked mutations (`report_blocked_mutations`, default `false`):** when a mutation targets a blocked
+sender's message, it is never performed. By default the result is reported as a successful no-op —
+indistinguishable from acting on a non-existent message, so the allowlist does not reveal that a hidden
+message exists. Set `report_blocked_mutations = true` (or `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS=true`)
+to instead report blocked UIDs as failures (explicit, but reveals a blocked-but-real message differs from
+a missing one).
 
 **Note:** matching is against the message's `From` header — local filtering only, not sender
 authentication. A spoofed `From` will pass the allowlist, so this is not a substitute for provider-side

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -245,8 +245,11 @@ async def list_allowed_recipients() -> list[str]:
 
 @mcp.tool(
     description=(
-        "List the configured inbound sender allowlist — the address patterns whose mail is visible "
-        "via list_emails_metadata and get_emails_content. Only available when an allowlist is configured."
+        "List the configured inbound sender allowlist — the address patterns whose mail the server "
+        "will read or act on. When configured, only these senders' mail is visible to the read tools "
+        "(list_emails_metadata, get_emails_content, download_attachment) and eligible for the mutation "
+        "tools (delete_emails, mark_emails_as_read, move_emails, archive_emails). Only available when an "
+        "allowlist is configured."
     ),
     visible_if=_has_allowed_senders,
 )

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -280,18 +280,22 @@ class Settings(BaseSettings):
     enable_attachment_download: bool = False
     allowed_recipients: list[str] = []
     allowed_senders: list[str] = []
+    report_blocked_mutations: bool = False
 
     model_config = SettingsConfigDict(toml_file=CONFIG_PATH, validate_assignment=True, revalidate_instances="always")
+
+    def _apply_bool_env_override(self, attr: str, env_var: str) -> None:
+        value = os.getenv(env_var)
+        if value is not None:
+            setattr(self, attr, _parse_bool_env(value, False))
+            logger.info(f"Set {attr}={getattr(self, attr)} from environment variable")
 
     def __init__(self, **data: Any) -> None:
         """Initialize Settings with support for environment variables."""
         super().__init__(**data)
 
-        # Check for enable_attachment_download from environment variable
-        env_enable_attachment = os.getenv("MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD")
-        if env_enable_attachment is not None:
-            self.enable_attachment_download = _parse_bool_env(env_enable_attachment, False)
-            logger.info(f"Set enable_attachment_download={self.enable_attachment_download} from environment variable")
+        self._apply_bool_env_override("enable_attachment_download", "MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD")
+        self._apply_bool_env_override("report_blocked_mutations", "MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS")
 
         # Normalise allowed_recipients from TOML (bare, lowercased, de-duplicated)
         if self.allowed_recipients:

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -268,6 +268,14 @@ def _raise_for_imap_error(response: Any, operation: str) -> None:
         raise RuntimeError(msg)
 
 
+def _raise_for_imap_command_failure(response: Any, operation: str) -> None:
+    """Raise only when an IMAP command reports an explicit failure status."""
+    if _imap_status(response) in {"NO", "BAD"}:
+        detail = _format_imap_response_detail(response)
+        msg = f"{operation} failed" + (f": {detail}" if detail else "")
+        raise RuntimeError(msg)
+
+
 def _html_to_text(html: str) -> str:
     """Convert an HTML email body to readable plain text."""
     soup = BeautifulSoup(html, "html.parser")
@@ -839,7 +847,9 @@ class EmailClient:
         for chunk in chunks:
             str_ids = [uid.decode() if isinstance(uid, bytes) else uid for uid in chunk]
             uid_list = ",".join(str_ids)
-            _, data = await imap.uid("fetch", uid_list, "BODY.PEEK[HEADER.FIELDS (FROM)]")
+            fetch_response = await imap.uid("fetch", uid_list, "BODY.PEEK[HEADER.FIELDS (FROM)]")
+            _raise_for_imap_command_failure(fetch_response, f"FETCH From headers for UIDs {uid_list}")
+            _, data = fetch_response
             for i, item in enumerate(data):
                 if not isinstance(item, bytes) or b"BODY[HEADER" not in item:
                     continue
@@ -1595,7 +1605,13 @@ class EmailClient:
                     failed_ids.append(email_id)
 
             if deleted_any:
-                await imap.expunge()
+                try:
+                    expunge_response = await imap.expunge()
+                    _raise_for_imap_error(expunge_response, "EXPUNGE deleted emails")
+                except Exception as e:
+                    logger.error(f"Failed to expunge deleted emails: {e}")
+                    failed_ids.extend(deleted_ids)
+                    deleted_ids = []
         finally:
             try:
                 await imap.logout()

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -873,6 +873,18 @@ class EmailClient:
                 logger.error(msg)
                 raise ValueError(msg)
 
+    async def _blocked_uids(
+        self,
+        imap: aioimaplib.IMAP4_SSL | aioimaplib.IMAP4,
+        email_ids: list[str],
+        allowed_senders: list[str] | None,
+    ) -> set[str]:
+        """UIDs whose From is not on the allowlist. Empty set when no allowlist (no IMAP work)."""
+        if not allowed_senders:
+            return set()
+        uid_senders = await self._batch_fetch_senders(imap, email_ids)
+        return {uid for uid in email_ids if not sender_allowed(uid_senders.get(uid, ""), allowed_senders)}
+
     async def get_emails_metadata(
         self,
         page: int = 1,
@@ -1544,8 +1556,19 @@ class EmailClient:
             except Exception as e:
                 logger.debug(f"Error during logout: {e}")
 
-    async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
-        """Delete emails by their UIDs. Returns (deleted_ids, failed_ids)."""
+    async def delete_emails(
+        self,
+        email_ids: list[str],
+        mailbox: str = "INBOX",
+        allowed_senders: list[str] | None = None,
+        report_blocked_mutations: bool = False,
+    ) -> tuple[list[str], list[str]]:
+        """Delete emails by their UIDs. Returns (deleted_ids, failed_ids).
+
+        A blocked sender's UID is never flagged \\Deleted: by default it is reported as a
+        no-op success (indistinguishable from a nonexistent UID); when
+        report_blocked_mutations is True it is reported in failed_ids instead.
+        """
         imap = await self._connect_imap()
         deleted_ids = []
         failed_ids = []
@@ -1556,15 +1579,23 @@ class EmailClient:
             select_response = await imap.select(_quote_mailbox(mailbox))
             _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
 
+            blocked = await self._blocked_uids(imap, email_ids, allowed_senders)
+            deleted_any = False
             for email_id in email_ids:
+                if email_id in blocked:
+                    (failed_ids if report_blocked_mutations else deleted_ids).append(email_id)
+                    continue
                 try:
-                    await imap.uid("store", email_id, "+FLAGS", r"(\Deleted)")
+                    store_response = await imap.uid("store", email_id, "+FLAGS", r"(\Deleted)")
+                    _raise_for_imap_error(store_response, f"STORE \\Deleted for email {email_id}")
                     deleted_ids.append(email_id)
+                    deleted_any = True
                 except Exception as e:
                     logger.error(f"Failed to delete email {email_id}: {e}")
                     failed_ids.append(email_id)
 
-            await imap.expunge()
+            if deleted_any:
+                await imap.expunge()
         finally:
             try:
                 await imap.logout()
@@ -1573,8 +1604,18 @@ class EmailClient:
 
         return deleted_ids, failed_ids
 
-    async def mark_emails_as_read(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
-        """Mark emails as read by setting the \\Seen flag. Returns (marked_ids, failed_ids)."""
+    async def mark_emails_as_read(
+        self,
+        email_ids: list[str],
+        mailbox: str = "INBOX",
+        allowed_senders: list[str] | None = None,
+        report_blocked_mutations: bool = False,
+    ) -> tuple[list[str], list[str]]:
+        """Mark emails as read by setting the \\Seen flag. Returns (marked_ids, failed_ids).
+
+        A blocked sender's UID is never flagged \\Seen: reported as a no-op success by
+        default, or in failed_ids when report_blocked_mutations is True.
+        """
         imap = await self._connect_imap()
         marked_ids: list[str] = []
         failed_ids: list[str] = []
@@ -1585,7 +1626,11 @@ class EmailClient:
             select_response = await imap.select(_quote_mailbox(mailbox))
             _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
 
+            blocked = await self._blocked_uids(imap, email_ids, allowed_senders)
             for email_id in email_ids:
+                if email_id in blocked:
+                    (failed_ids if report_blocked_mutations else marked_ids).append(email_id)
+                    continue
                 try:
                     store_response = await imap.uid("store", email_id, "+FLAGS", r"(\Seen)")
                     _raise_for_imap_error(store_response, f"STORE \\Seen for email {email_id}")
@@ -1602,9 +1647,18 @@ class EmailClient:
         return marked_ids, failed_ids
 
     async def move_emails(
-        self, email_ids: list[str], source_mailbox: str, destination_mailbox: str
+        self,
+        email_ids: list[str],
+        source_mailbox: str,
+        destination_mailbox: str,
+        allowed_senders: list[str] | None = None,
+        report_blocked_mutations: bool = False,
     ) -> tuple[list[str], list[str]]:
-        """Move emails to a different mailbox. Uses IMAP MOVE (RFC 6851) with COPY+DELETE fallback."""
+        """Move emails to a different mailbox. Uses IMAP MOVE (RFC 6851) with COPY+DELETE fallback.
+
+        A blocked sender's UID is never copied/moved: reported as a no-op success by default,
+        or in failed_ids when report_blocked_mutations is True.
+        """
         imap = await self._connect_imap()
         moved_ids = []
         failed_ids = []
@@ -1618,7 +1672,12 @@ class EmailClient:
             capabilities = {str(capability).upper() for capability in getattr(imap, "capabilities", ())}
             has_move = hasattr(imap, "move") and "MOVE" in capabilities
 
+            blocked = await self._blocked_uids(imap, email_ids, allowed_senders)
+            copied: list[str] = []  # allowed UIDs that actually completed COPY+STORE on the fallback path
             for email_id in email_ids:
+                if email_id in blocked:
+                    (failed_ids if report_blocked_mutations else moved_ids).append(email_id)
+                    continue
                 try:
                     if has_move:
                         move_response = await imap.uid("move", email_id, _quote_mailbox(destination_mailbox))
@@ -1628,19 +1687,20 @@ class EmailClient:
                         _raise_for_imap_error(copy_response, f"COPY email {email_id}")
                         store_response = await imap.uid("store", email_id, "+FLAGS", r"(\Deleted)")
                         _raise_for_imap_error(store_response, f"STORE \\Deleted for email {email_id}")
+                        copied.append(email_id)
                     moved_ids.append(email_id)
                 except Exception as e:
                     logger.error(f"Failed to move email {email_id}: {e}")
                     failed_ids.append(email_id)
 
-            if not has_move and moved_ids:
+            if copied:  # only expunge when real COPY+STORE happened — never for blocked/no-op UIDs
                 try:
                     expunge_response = await imap.expunge()
                     _raise_for_imap_error(expunge_response, "EXPUNGE moved emails")
                 except Exception as e:
                     logger.error(f"Failed to expunge moved emails: {e}")
-                    failed_ids.extend(moved_ids)
-                    moved_ids = []
+                    failed_ids.extend(copied)
+                    moved_ids = [uid for uid in moved_ids if uid not in set(copied)]
         finally:
             try:
                 await imap.logout()
@@ -1884,17 +1944,36 @@ class ClassicEmailHandler(EmailHandler):
 
     async def delete_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """Delete emails by their UIDs. Returns (deleted_ids, failed_ids)."""
-        return await self.incoming_client.delete_emails(email_ids, mailbox)
+        settings = get_settings()
+        return await self.incoming_client.delete_emails(
+            email_ids,
+            mailbox,
+            allowed_senders=settings.allowed_senders,
+            report_blocked_mutations=settings.report_blocked_mutations,
+        )
 
     async def mark_emails_as_read(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
         """Mark emails as read by their UIDs. Returns (marked_ids, failed_ids)."""
-        return await self.incoming_client.mark_emails_as_read(email_ids, mailbox)
+        settings = get_settings()
+        return await self.incoming_client.mark_emails_as_read(
+            email_ids,
+            mailbox,
+            allowed_senders=settings.allowed_senders,
+            report_blocked_mutations=settings.report_blocked_mutations,
+        )
 
     async def move_emails(
         self, email_ids: list[str], source_mailbox: str, destination_mailbox: str
     ) -> tuple[list[str], list[str]]:
         """Move emails between mailboxes. Returns (moved_ids, failed_ids)."""
-        return await self.incoming_client.move_emails(email_ids, source_mailbox, destination_mailbox)
+        settings = get_settings()
+        return await self.incoming_client.move_emails(
+            email_ids,
+            source_mailbox,
+            destination_mailbox,
+            allowed_senders=settings.allowed_senders,
+            report_blocked_mutations=settings.report_blocked_mutations,
+        )
 
     async def _find_archive_folder(self) -> str | None:
         """Locate the Archive folder via the RFC 6154 ``\\Archive`` flag, then common names."""
@@ -1918,7 +1997,14 @@ class ClassicEmailHandler(EmailHandler):
                 "No Archive folder found (looked for the RFC 6154 \\Archive flag and common names: "
                 f"{', '.join(_ARCHIVE_FOLDER_CANDIDATES)}). Use move_emails with an explicit folder instead."
             )
-        moved_ids, failed_ids = await self.incoming_client.move_emails(email_ids, mailbox, archive_folder)
+        settings = get_settings()
+        moved_ids, failed_ids = await self.incoming_client.move_emails(
+            email_ids,
+            mailbox,
+            archive_folder,
+            allowed_senders=settings.allowed_senders,
+            report_blocked_mutations=settings.report_blocked_mutations,
+        )
         return moved_ids, failed_ids, archive_folder
 
     async def list_mailboxes(self, pattern: str = "*", reference: str = "") -> list[MailboxInfo]:

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -315,7 +315,9 @@ class TestClassicEmailHandler:
 
             assert deleted_ids == ["123", "456"]
             assert failed_ids == []
-            mock_delete.assert_called_once_with(["123", "456"], "INBOX")
+            mock_delete.assert_called_once_with(
+                ["123", "456"], "INBOX", allowed_senders=[], report_blocked_mutations=False
+            )
 
     @pytest.mark.asyncio
     async def test_delete_emails_with_failures(self, classic_handler):
@@ -330,7 +332,9 @@ class TestClassicEmailHandler:
 
             assert deleted_ids == ["123"]
             assert failed_ids == ["456"]
-            mock_delete.assert_called_once_with(["123", "456"], "Trash")
+            mock_delete.assert_called_once_with(
+                ["123", "456"], "Trash", allowed_senders=[], report_blocked_mutations=False
+            )
 
     @pytest.mark.asyncio
     async def test_delete_emails_custom_mailbox(self, classic_handler):
@@ -345,7 +349,7 @@ class TestClassicEmailHandler:
 
             assert deleted_ids == ["789"]
             assert failed_ids == []
-            mock_delete.assert_called_once_with(["789"], "Archive")
+            mock_delete.assert_called_once_with(["789"], "Archive", allowed_senders=[], report_blocked_mutations=False)
 
     @pytest.mark.asyncio
     async def test_mark_emails_as_read(self, classic_handler):
@@ -360,7 +364,9 @@ class TestClassicEmailHandler:
 
             assert marked_ids == ["123", "456"]
             assert failed_ids == []
-            mock_mark.assert_called_once_with(["123", "456"], "INBOX")
+            mock_mark.assert_called_once_with(
+                ["123", "456"], "INBOX", allowed_senders=[], report_blocked_mutations=False
+            )
 
     @pytest.mark.asyncio
     async def test_mark_emails_as_read_with_failures(self, classic_handler):
@@ -375,7 +381,9 @@ class TestClassicEmailHandler:
 
             assert marked_ids == ["123"]
             assert failed_ids == ["456"]
-            mock_mark.assert_called_once_with(["123", "456"], "INBOX")
+            mock_mark.assert_called_once_with(
+                ["123", "456"], "INBOX", allowed_senders=[], report_blocked_mutations=False
+            )
 
     @pytest.mark.asyncio
     async def test_mark_emails_as_read_custom_mailbox(self, classic_handler):
@@ -390,7 +398,7 @@ class TestClassicEmailHandler:
 
             assert marked_ids == ["789"]
             assert failed_ids == []
-            mock_mark.assert_called_once_with(["789"], "Archive")
+            mock_mark.assert_called_once_with(["789"], "Archive", allowed_senders=[], report_blocked_mutations=False)
 
     @pytest.mark.asyncio
     async def test_download_attachment(self, classic_handler, tmp_path):
@@ -633,6 +641,55 @@ class TestClassicEmailHandler:
         assert result.retrieved_count == 1
         assert mock_get.call_args.args[2] is True  # mark passed through to fetch
         mock_mark.assert_not_called()  # no deferred batch-mark when not filtering
+
+    @pytest.mark.asyncio
+    async def test_delete_emails_passes_allowlist_and_report_flag(self, classic_handler):
+        mock_delete = AsyncMock(return_value=(["1"], []))
+        with patch(
+            "mcp_email_server.emails.classic.get_settings",
+            return_value=MagicMock(allowed_senders=["*@example.com"], report_blocked_mutations=True),
+        ):
+            with patch.object(classic_handler.incoming_client, "delete_emails", mock_delete):
+                await classic_handler.delete_emails(["1"], "INBOX")
+        assert mock_delete.call_args.kwargs.get("allowed_senders") == ["*@example.com"]
+        assert mock_delete.call_args.kwargs.get("report_blocked_mutations") is True
+
+    @pytest.mark.asyncio
+    async def test_mark_emails_as_read_passes_allowlist_and_report_flag(self, classic_handler):
+        mock_mark = AsyncMock(return_value=(["1"], []))
+        with patch(
+            "mcp_email_server.emails.classic.get_settings",
+            return_value=MagicMock(allowed_senders=["*@example.com"], report_blocked_mutations=False),
+        ):
+            with patch.object(classic_handler.incoming_client, "mark_emails_as_read", mock_mark):
+                await classic_handler.mark_emails_as_read(["1"], "INBOX")
+        assert mock_mark.call_args.kwargs.get("allowed_senders") == ["*@example.com"]
+        assert mock_mark.call_args.kwargs.get("report_blocked_mutations") is False
+
+    @pytest.mark.asyncio
+    async def test_move_emails_passes_allowlist_and_report_flag(self, classic_handler):
+        mock_move = AsyncMock(return_value=(["1"], []))
+        with patch(
+            "mcp_email_server.emails.classic.get_settings",
+            return_value=MagicMock(allowed_senders=["*@example.com"], report_blocked_mutations=True),
+        ):
+            with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+                await classic_handler.move_emails(["1"], "INBOX", "Archive")
+        assert mock_move.call_args.kwargs.get("allowed_senders") == ["*@example.com"]
+        assert mock_move.call_args.kwargs.get("report_blocked_mutations") is True
+
+    @pytest.mark.asyncio
+    async def test_archive_emails_passes_allowlist_and_report_flag(self, classic_handler):
+        mock_move = AsyncMock(return_value=(["1"], []))
+        with patch(
+            "mcp_email_server.emails.classic.get_settings",
+            return_value=MagicMock(allowed_senders=["*@example.com"], report_blocked_mutations=True),
+        ):
+            with patch.object(classic_handler, "_find_archive_folder", AsyncMock(return_value="Archive")):
+                with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+                    await classic_handler.archive_emails(["1"], "INBOX")
+        assert mock_move.call_args.kwargs.get("allowed_senders") == ["*@example.com"]
+        assert mock_move.call_args.kwargs.get("report_blocked_mutations") is True
 
 
 class TestEmailClientGetEmailBodyById:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,3 +229,54 @@ def test_allowed_senders_toml_normalised_preserves_globs(tmp_path, monkeypatch):
         assert config_module.get_settings(reload=True).allowed_senders == ["*@example.com", "bob@example.com"]
     finally:
         config_module._settings = None
+
+
+def test_report_blocked_mutations_defaults_to_false(tmp_path, monkeypatch):
+    import tomli_w
+
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_bytes(tomli_w.dumps({}).encode())
+    monkeypatch.delenv("MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS", raising=False)
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        assert config_module.get_settings(reload=True).report_blocked_mutations is False
+    finally:
+        config_module._settings = None
+
+
+def test_report_blocked_mutations_from_toml(tmp_path, monkeypatch):
+    import tomli_w
+
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_bytes(tomli_w.dumps({"report_blocked_mutations": True}).encode())
+    monkeypatch.delenv("MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS", raising=False)
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        assert config_module.get_settings(reload=True).report_blocked_mutations is True
+    finally:
+        config_module._settings = None
+
+
+def test_report_blocked_mutations_env_overrides_toml(tmp_path, monkeypatch):
+    import tomli_w
+
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_bytes(tomli_w.dumps({"report_blocked_mutations": False}).encode())
+    monkeypatch.setenv("MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS", "true")
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        assert config_module.get_settings(reload=True).report_blocked_mutations is True
+    finally:
+        config_module._settings = None

--- a/tests/test_move_and_list_mailboxes.py
+++ b/tests/test_move_and_list_mailboxes.py
@@ -618,7 +618,9 @@ class TestClassicHandlerMoveEmails:
 
         assert moved == ["100", "200"]
         assert failed == []
-        mock_move.assert_called_once_with(["100", "200"], "INBOX", "Archive")
+        mock_move.assert_called_once_with(
+            ["100", "200"], "INBOX", "Archive", allowed_senders=[], report_blocked_mutations=False
+        )
 
     @pytest.mark.asyncio
     async def test_move_emails_with_failures(self, classic_handler):
@@ -634,7 +636,9 @@ class TestClassicHandlerMoveEmails:
 
         assert moved == ["100"]
         assert failed == ["200"]
-        mock_move.assert_called_once_with(["100", "200"], "INBOX", "Trash")
+        mock_move.assert_called_once_with(
+            ["100", "200"], "INBOX", "Trash", allowed_senders=[], report_blocked_mutations=False
+        )
 
     @pytest.mark.asyncio
     async def test_move_emails_custom_source(self, classic_handler):
@@ -649,7 +653,7 @@ class TestClassicHandlerMoveEmails:
             )
 
         assert moved == ["300"]
-        mock_move.assert_called_once_with(["300"], "Trash", "INBOX")
+        mock_move.assert_called_once_with(["300"], "Trash", "INBOX", allowed_senders=[], report_blocked_mutations=False)
 
 
 class TestClassicHandlerArchiveEmails:
@@ -672,7 +676,9 @@ class TestClassicHandlerArchiveEmails:
         assert moved == ["100"]
         assert failed == []
         assert archive_folder == "All Mail"
-        mock_move.assert_called_once_with(["100"], "INBOX", "All Mail")
+        mock_move.assert_called_once_with(
+            ["100"], "INBOX", "All Mail", allowed_senders=[], report_blocked_mutations=False
+        )
 
     @pytest.mark.asyncio
     async def test_archive_falls_back_to_common_name(self, classic_handler):
@@ -690,7 +696,9 @@ class TestClassicHandlerArchiveEmails:
 
         assert moved == ["100", "200"]
         assert archive_folder == "Archive"
-        mock_move.assert_called_once_with(["100", "200"], "INBOX", "Archive")
+        mock_move.assert_called_once_with(
+            ["100", "200"], "INBOX", "Archive", allowed_senders=[], report_blocked_mutations=False
+        )
 
     @pytest.mark.asyncio
     async def test_archive_fallback_preserves_server_mailbox_case(self, classic_handler):
@@ -709,7 +717,9 @@ class TestClassicHandlerArchiveEmails:
         assert moved == ["100"]
         assert failed == []
         assert archive_folder == "archive"
-        mock_move.assert_called_once_with(["100"], "INBOX", "archive")
+        mock_move.assert_called_once_with(
+            ["100"], "INBOX", "archive", allowed_senders=[], report_blocked_mutations=False
+        )
 
     @pytest.mark.asyncio
     async def test_archive_raises_when_no_archive_folder(self, classic_handler):

--- a/tests/test_mutation_allowlist.py
+++ b/tests/test_mutation_allowlist.py
@@ -1,0 +1,204 @@
+"""Sender-allowlist enforcement on the UID mutation tools."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_email_server.emails.classic import EmailClient
+
+
+@pytest.fixture
+def email_client(email_server):  # email_server comes from conftest.py
+    return EmailClient(email_server)
+
+
+def _make_mock_imap(**overrides):
+    """AsyncMock IMAP client with sensible mutation defaults (uid/expunge return OK)."""
+    mock = AsyncMock()
+    mock._client_task = asyncio.Future()
+    mock._client_task.set_result(None)
+    mock.wait_hello_from_server = AsyncMock()
+    mock.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+    mock.select = AsyncMock(return_value=("OK", []))
+    mock.uid = AsyncMock(return_value=("OK", []))
+    mock.expunge = AsyncMock(return_value=("OK", []))
+    mock.logout = AsyncMock()
+    for k, v in overrides.items():
+        setattr(mock, k, v)
+    return mock
+
+
+def _uid_op_targets(mock_imap, op):
+    """UIDs that a given uid(op, uid, ...) command was issued for."""
+    return [c.args[1] for c in mock_imap.uid.call_args_list if c.args and c.args[0] == op]
+
+
+class TestDeleteEmailsAllowlist:
+    @pytest.mark.asyncio
+    async def test_blocked_uid_not_deleted_default_silent(self, email_client):
+        mock_imap = _make_mock_imap()
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            deleted, failed = await email_client.delete_emails(["1", "2"], allowed_senders=["*@allowed.com"])
+        # default: blocked "2" is a no-op success (never flagged), allowed "1" deleted
+        assert deleted == ["1", "2"]
+        assert failed == []
+        assert _uid_op_targets(mock_imap, "store") == ["1"]  # blocked UID never STOREd \Deleted
+
+    @pytest.mark.asyncio
+    async def test_blocked_uid_reported_when_configured(self, email_client):
+        mock_imap = _make_mock_imap()
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            deleted, failed = await email_client.delete_emails(
+                ["1", "2"], allowed_senders=["*@allowed.com"], report_blocked_mutations=True
+            )
+        assert deleted == ["1"]
+        assert failed == ["2"]
+        assert _uid_op_targets(mock_imap, "store") == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_no_sender_fetch(self, email_client):
+        mock_imap = _make_mock_imap()
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock()) as mock_senders,
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            deleted, failed = await email_client.delete_emails(["1", "2"], allowed_senders=[])
+        assert deleted == ["1", "2"]
+        assert failed == []
+        mock_senders.assert_not_called()  # no allowlist => no extra IMAP work
+
+    @pytest.mark.asyncio
+    async def test_all_blocked_no_store_no_expunge(self, email_client):
+        mock_imap = _make_mock_imap()
+        senders = {"1": "evil@blocked.com", "2": "spam@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            deleted, failed = await email_client.delete_emails(["1", "2"], allowed_senders=["*@allowed.com"])
+        assert deleted == ["1", "2"]  # silent no-op success
+        assert failed == []
+        assert _uid_op_targets(mock_imap, "store") == []  # no STORE issued
+        mock_imap.expunge.assert_not_called()  # and crucially, no EXPUNGE
+
+
+class TestMarkAsReadAllowlist:
+    @pytest.mark.asyncio
+    async def test_blocked_uid_not_marked_default_silent(self, email_client):
+        mock_imap = _make_mock_imap()
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            marked, failed = await email_client.mark_emails_as_read(["1", "2"], allowed_senders=["*@allowed.com"])
+        assert marked == ["1", "2"]
+        assert failed == []
+        assert _uid_op_targets(mock_imap, "store") == ["1"]  # blocked UID never STOREd \Seen
+
+    @pytest.mark.asyncio
+    async def test_blocked_uid_reported_when_configured(self, email_client):
+        mock_imap = _make_mock_imap()
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            marked, failed = await email_client.mark_emails_as_read(
+                ["1", "2"], allowed_senders=["*@allowed.com"], report_blocked_mutations=True
+            )
+        assert marked == ["1"]
+        assert failed == ["2"]
+        assert _uid_op_targets(mock_imap, "store") == ["1"]
+
+
+class TestMoveEmailsAllowlist:
+    @pytest.mark.asyncio
+    async def test_blocked_uid_not_moved_default_silent(self, email_client):
+        mock_imap = _make_mock_imap(move=AsyncMock(return_value=("OK", [])), capabilities=("IMAP4rev1", "MOVE"))
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            moved, failed = await email_client.move_emails(
+                ["1", "2"], "INBOX", "Archive", allowed_senders=["*@allowed.com"]
+            )
+        assert moved == ["1", "2"]
+        assert failed == []
+        assert _uid_op_targets(mock_imap, "move") == ["1"]  # blocked UID never MOVEd
+
+    @pytest.mark.asyncio
+    async def test_blocked_uid_reported_when_configured(self, email_client):
+        mock_imap = _make_mock_imap(move=AsyncMock(return_value=("OK", [])), capabilities=("IMAP4rev1", "MOVE"))
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            moved, failed = await email_client.move_emails(
+                ["1", "2"], "INBOX", "Archive", allowed_senders=["*@allowed.com"], report_blocked_mutations=True
+            )
+        assert moved == ["1"]
+        assert failed == ["2"]
+        assert _uid_op_targets(mock_imap, "move") == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_blocked_uid_not_copied_on_fallback_default_silent(self, email_client):
+        # No MOVE capability -> COPY + STORE \Deleted fallback path
+        mock_imap = _make_mock_imap(capabilities=("IMAP4rev1",))
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            moved, failed = await email_client.move_emails(
+                ["1", "2"], "INBOX", "Archive", allowed_senders=["*@allowed.com"]
+            )
+        assert moved == ["1", "2"]  # blocked "2" is a silent no-op success
+        assert failed == []
+        assert _uid_op_targets(mock_imap, "copy") == ["1"]  # blocked UID never COPYed
+        assert _uid_op_targets(mock_imap, "store") == ["1"]  # blocked UID never STOREd \Deleted
+
+    @pytest.mark.asyncio
+    async def test_all_blocked_fallback_no_copy_no_store_no_expunge(self, email_client):
+        mock_imap = _make_mock_imap(capabilities=("IMAP4rev1",))  # no MOVE -> COPY+STORE fallback
+        senders = {"1": "evil@blocked.com", "2": "spam@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            moved, failed = await email_client.move_emails(
+                ["1", "2"], "INBOX", "Archive", allowed_senders=["*@allowed.com"]
+            )
+        assert moved == ["1", "2"]
+        assert failed == []
+        assert _uid_op_targets(mock_imap, "copy") == []
+        assert _uid_op_targets(mock_imap, "store") == []
+        mock_imap.expunge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mixed_fallback_expunge_only_from_allowed_work(self, email_client):
+        mock_imap = _make_mock_imap(capabilities=("IMAP4rev1",))  # fallback path
+        senders = {"1": "ok@allowed.com", "2": "evil@blocked.com"}
+        with (
+            patch.object(email_client, "_batch_fetch_senders", AsyncMock(return_value=senders)),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            moved, failed = await email_client.move_emails(
+                ["1", "2"], "INBOX", "Archive", allowed_senders=["*@allowed.com"]
+            )
+        assert moved == ["1", "2"]  # "1" moved, "2" silent no-op
+        assert failed == []
+        assert _uid_op_targets(mock_imap, "copy") == ["1"]  # only allowed UID copied
+        assert _uid_op_targets(mock_imap, "store") == ["1"]  # only allowed UID \Deleted-flagged
+        mock_imap.expunge.assert_called_once()  # expunge from real work, not the no-op

--- a/tests/test_mutation_allowlist.py
+++ b/tests/test_mutation_allowlist.py
@@ -90,6 +90,34 @@ class TestDeleteEmailsAllowlist:
         assert _uid_op_targets(mock_imap, "store") == []  # no STORE issued
         mock_imap.expunge.assert_not_called()  # and crucially, no EXPUNGE
 
+    @pytest.mark.asyncio
+    async def test_sender_fetch_failure_is_not_reported_as_silent_success(self, email_client):
+        mock_imap = _make_mock_imap()
+
+        async def uid_side_effect(command, *args):
+            if command == "fetch":
+                return "NO", [b"FETCH failed"]
+            return "OK", []
+
+        mock_imap.uid = AsyncMock(side_effect=uid_side_effect)
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with pytest.raises(RuntimeError, match="FETCH From headers for UIDs 1,2 failed"):
+                await email_client.delete_emails(["1", "2"], allowed_senders=["*@allowed.com"])
+
+        assert _uid_op_targets(mock_imap, "store") == []
+        mock_imap.expunge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_expunge_failure_reports_delete_failure(self, email_client):
+        mock_imap = _make_mock_imap(expunge=AsyncMock(return_value=("NO", [b"EXPUNGE failed"])))
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            deleted, failed = await email_client.delete_emails(["1", "2"], allowed_senders=[])
+
+        assert deleted == []
+        assert failed == ["1", "2"]
+        assert _uid_op_targets(mock_imap, "store") == ["1", "2"]
+        mock_imap.expunge.assert_called_once()
+
 
 class TestMarkAsReadAllowlist:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #180 (merged): extends the global **sender allowlist** to the UID **mutation** tools, completing the scope that #180 deferred. #180 covered the inbound read paths and documented that the mutation tools were not yet filtered — this PR closes that gap.

When `allowed_senders` is set, `delete_emails`, `mark_emails_as_read`, `move_emails`, and `archive_emails` (which delegates to `move_emails`) check the message `From` header before mutating, and **never delete, flag, or move a blocked sender's message**. When the allowlist is empty (the default), behavior is unchanged with no extra IMAP work.

- A single batched `FROM`-only fetch (`BODY.PEEK[HEADER.FIELDS (FROM)]`) per mutation call computes the blocked set, reusing the existing read-path matcher; zero extra work when no allowlist is configured.
- New setting **`report_blocked_mutations`** (default `false`) controls how a skipped blocked UID is reported (see below).
- README updated: the allowlist scope now covers read **and** mutation paths.

## Configurable reporting: `report_blocked_mutations`

A blocked sender's UID is never mutated in either mode — the setting only controls how the skip is reported:

- **`false` (default) — silent no-op success.** The blocked UID is reported as a successful no-op, exactly as IMAP already treats a mutation on a nonexistent UID. This keeps a blocked-but-real message **indistinguishable from a nonexistent one**, so the allowlist does not reveal that a hidden message exists.
- **`true` — explicit failure.** The blocked UID is reported in the tool's failure list. More transparent (no silent no-op), at the cost of revealing that a blocked-but-real UID differs from a nonexistent one.

Configurable via TOML (`report_blocked_mutations = true`) or env (`MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS=true`).

## Motivation

The sender allowlist limits an MCP assistant's inbound exposure to trusted senders. #180 secured the read paths; without this change a client that knows or guesses a blocked sender's UID could still delete/flag/move that mail — an integrity gap. This closes it, so the allowlist governs every inbound path.

## Test plan

- [x] Each mutation tool: a blocked UID's IMAP op (`STORE \Deleted` / `STORE \Seen` / `MOVE` / `COPY`+`STORE \Deleted`) is **never issued** (asserted via call-args), on both the MOVE and COPY+STORE-fallback paths
- [x] Default → blocked reported as a no-op success; `report_blocked_mutations=true` → blocked reported as a failure
- [x] Allowed UIDs still mutated normally; `archive_emails` inherits enforcement via `move_emails`
- [x] Empty allowlist → no `FROM` fetch, behavior unchanged (backwards-compatible)
- [x] `report_blocked_mutations` config: default `false`; TOML + env parsing; env overrides TOML
- [x] Full suite green (405 tests); `make check` clean (ruff, prettier, deptry)

## Note

Matching is against the RFC 5322 `From` header — local filtering, not sender authentication (same caveat as #180; not a substitute for provider-side SPF/DKIM/DMARC).

Refs #180, #142

## Transparency note

Written by [Claude Code](https://claude.com/claude-code) using the Superpowers plugin, following a spec + implementation plan designed collaboratively with the author, with per-task and whole-branch automated review. All code reviewed by the author before submission. Commits include `Co-Authored-By: Claude Opus 4.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
