### PR TITLE
fix: declare CHARSET utf-8 for non-ASCII search criteria

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -900,11 +900,17 @@ class EmailClient:
             logger.info(f"Get metadata: Search criteria: {search_criteria}")
 
             # Search for messages - use UID SEARCH for better compatibility.
-            # charset=None: aioimaplib defaults to "CHARSET utf-8", which Microsoft
-            # Exchange rejects with `NO [BADCHARSET (US-ASCII)] The specified charset
-            # is not supported.`, breaking all search/list operations. Omitting the
-            # CHARSET token works on Exchange and is harmless on other servers.
-            _, messages = await imap.uid_search(*search_criteria, charset=None)
+            # charset handling: aioimaplib defaults to "CHARSET utf-8", which
+            # Microsoft Exchange rejects with `NO [BADCHARSET (US-ASCII)] The
+            # specified charset is not supported.`, breaking all search/list
+            # operations — so ASCII-only searches omit the CHARSET token entirely.
+            # However, RFC 3501 requires a charset declaration for non-ASCII
+            # search values: without it, servers such as Coremail interpret the
+            # raw UTF-8 bytes as US-ASCII and silently return zero matches. So
+            # declare UTF-8 only when the criteria actually contain non-ASCII
+            # characters; the Exchange-sensitive ASCII path is unchanged.
+            charset = "utf-8" if any(not criterion.isascii() for criterion in search_criteria) else None
+            _, messages = await imap.uid_search(*search_criteria, charset=charset)
 
             # Handle empty or None responses
             if not messages or not messages[0]:

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -903,13 +903,14 @@ class EmailClient:
             # charset handling: aioimaplib defaults to "CHARSET utf-8", which
             # Microsoft Exchange rejects with `NO [BADCHARSET (US-ASCII)] The
             # specified charset is not supported.`, breaking all search/list
-            # operations — so ASCII-only searches omit the CHARSET token entirely.
+            # operations — so ASCII-only user searches omit the CHARSET token.
             # However, RFC 3501 requires a charset declaration for non-ASCII
             # search values: without it, servers such as Coremail interpret the
-            # raw UTF-8 bytes as US-ASCII and silently return zero matches. So
-            # declare UTF-8 only when the criteria actually contain non-ASCII
-            # characters; the Exchange-sensitive ASCII path is unchanged.
-            charset = "utf-8" if any(not criterion.isascii() for criterion in search_criteria) else None
+            # raw UTF-8 bytes as US-ASCII and silently return zero matches. Base
+            # the decision only on user-supplied text fields, not on generated
+            # criteria such as locale-dependent date strings.
+            search_text_values = (subject, body, text, from_address, to_address)
+            charset = "utf-8" if any(value and not value.isascii() for value in search_text_values) else None
             _, messages = await imap.uid_search(*search_criteria, charset=charset)
 
             # Handle empty or None responses

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -441,11 +441,12 @@ class TestEmailClient:
 
     @pytest.mark.asyncio
     async def test_get_emails_metadata_search_omits_charset(self, email_client):
-        """UID SEARCH must not send 'CHARSET utf-8'.
+        """ASCII-only UID SEARCH must not send 'CHARSET utf-8'.
 
         aioimaplib defaults to charset='utf-8'; Microsoft Exchange rejects that
         with `NO [BADCHARSET (US-ASCII)]`, breaking all search/list operations.
-        We must pass charset=None so no CHARSET token is sent.
+        For ASCII-only criteria we must pass charset=None so no CHARSET token
+        is sent.
         """
         mock_imap = AsyncMock()
         mock_imap._client_task = asyncio.Future()
@@ -461,6 +462,31 @@ class TestEmailClient:
 
         mock_imap.uid_search.assert_called_once()
         assert mock_imap.uid_search.call_args.kwargs.get("charset") is None
+
+    @pytest.mark.asyncio
+    async def test_get_emails_metadata_search_declares_utf8_for_non_ascii(self, email_client):
+        """Non-ASCII (e.g. CJK) UID SEARCH must declare 'CHARSET utf-8'.
+
+        RFC 3501 requires a charset declaration for non-ASCII search values;
+        without it, servers such as Coremail interpret the raw UTF-8 bytes as
+        US-ASCII and silently return zero matches. ASCII-only searches keep
+        charset=None for Exchange compatibility (see the companion test above).
+        """
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b""]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            await email_client.get_emails_metadata(mailbox="INBOX", subject="会议")
+
+        mock_imap.uid_search.assert_called_once()
+        assert mock_imap.uid_search.call_args.kwargs.get("charset") == "utf-8"
+        assert "会议" in mock_imap.uid_search.call_args.args
 
     @pytest.mark.asyncio
     async def test_get_emails_metadata_falls_back_to_uid_order_when_dates_missing(self, email_client):

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -489,6 +489,31 @@ class TestEmailClient:
         assert "会议" in mock_imap.uid_search.call_args.args
 
     @pytest.mark.asyncio
+    async def test_get_emails_metadata_search_ignores_non_ascii_generated_criteria(self, email_client):
+        """Generated criteria must not trigger UTF-8 charset by themselves.
+
+        Date strings are generated internally and may be locale-dependent. They
+        should not cause charset='utf-8' for an otherwise ASCII-only user search,
+        because that would reintroduce the Exchange BADCHARSET failure.
+        """
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", []))
+        mock_imap.uid_search = AsyncMock(return_value=(None, [b""]))
+        mock_imap.logout = AsyncMock()
+
+        with patch.object(email_client, "imap_class", return_value=mock_imap):
+            with patch.object(EmailClient, "_build_search_criteria", return_value=["SINCE", "01-MÄR-2026"]):
+                await email_client.get_emails_metadata(mailbox="INBOX")
+
+        mock_imap.uid_search.assert_called_once()
+        assert mock_imap.uid_search.call_args.kwargs.get("charset") is None
+        assert mock_imap.uid_search.call_args.args == ("SINCE", "01-MÄR-2026")
+
+    @pytest.mark.asyncio
     async def test_get_emails_metadata_falls_back_to_uid_order_when_dates_missing(self, email_client):
         """Metadata listing should still return emails when INTERNALDATE parsing fails."""
         mock_imap = AsyncMock()


### PR DESCRIPTION
Fixes #189

## Problem

Non-ASCII (e.g. CJK) search terms in `list_emails_metadata` silently return zero results: since #178, UID SEARCH always omits the CHARSET token, so servers like Coremail interpret the raw UTF-8 bytes as US-ASCII. Details and server-side evidence in #189.

## Change

`EmailClient.get_emails_metadata`: pass `charset="utf-8"` to `uid_search` **only** when the built criteria contain non-ASCII characters. ASCII-only searches still send no CHARSET token, so the Exchange fix from #178 is fully preserved.

## Tests

- Updated `test_get_emails_metadata_search_omits_charset` (ASCII-only criteria still omit CHARSET).
- Added `test_get_emails_metadata_search_declares_utf8_for_non_ascii` (CJK criteria declare `utf-8`).
- Full suite: 391 passed.

## Real-server verification (Tsinghua Coremail)

With this patch against a real mailbox: `subject="会议"` → 34 hits, `body="会议"` → 61 hits (both 0 before the patch; numbers match a raw-IMAP control test with explicit `CHARSET utf-8`).
