### PR TITLE
fix(email): encode only sender display name

### DIFF
--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1297,8 +1297,13 @@ class EmailClient:
         else:
             msg["Subject"] = subject
 
-        # Handle sender name with special characters
-        if any(ord(c) > 127 for c in self.sender):
+        sender_name, sender_address = email.utils.parseaddr(self.sender)
+
+        # Encode only the display name. RFC 2047 encoded-words must not cover the
+        # addr-spec, otherwise strict clients may show the raw encoded blob.
+        if sender_address:
+            msg["From"] = email.utils.formataddr((str(Header(sender_name, "utf-8")), sender_address))
+        elif any(ord(c) > 127 for c in self.sender):
             msg["From"] = Header(self.sender, "utf-8")
         else:
             msg["From"] = self.sender
@@ -1323,7 +1328,8 @@ class EmailClient:
 
         # Set Date and Message-Id headers
         msg["Date"] = email.utils.formatdate(localtime=True)
-        sender_domain = self.sender.rsplit("@", 1)[-1].rstrip(">")
+        sender_for_domain = sender_address or self.sender
+        sender_domain = sender_for_domain.rsplit("@", 1)[-1].rstrip(">")
         msg["Message-Id"] = email.utils.make_msgid(domain=sender_domain)
 
         return msg

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -721,6 +721,22 @@ class TestEmailClient:
 
 
 class TestSendEmailMessageIdAndDate:
+    def test_compose_message_encodes_only_non_ascii_sender_display_name(self, email_server):
+        """Non-ASCII display names must not encode the addr-spec in the From header."""
+        client = EmailClient(email_server, sender="刘滨瑞 <lbr1@mails.tsinghua.edu.cn>")
+
+        msg = client.compose_message(
+            recipients=["recipient@example.com"],
+            subject="Test Subject",
+            body="Test Body",
+        )
+
+        serialized = msg.as_string()
+        from_header = next(line for line in serialized.splitlines() if line.startswith("From:"))
+        assert from_header.startswith("From: =?utf-8?")
+        assert "<lbr1@mails.tsinghua.edu.cn>" in from_header
+        assert "@mails.tsinghua.edu.cn>" in msg["Message-Id"]
+
     @pytest.mark.asyncio
     async def test_send_email_sets_message_id_and_date(self, email_client):
         """Test that send_email sets Message-Id and Date headers."""


### PR DESCRIPTION
Encode only the sender display name when building the From header so strict clients do not render an encoded addr-spec. Use the parsed sender address for Message-Id domain generation.

Assisted-by: YAAI <261597362+yaai-bot@users.noreply.github.com>
