### PR TITLE
feat: allow save_to_mailbox without SMTP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                              | `true`        | No       |
 | `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                         | `false`       | No       |
 | `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)       | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for read-only mode                    | -             | No       |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for IMAP-only mode (no sending)       | -             | No       |
 | `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                             | `465`         | No       |
 | `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                              | `true`        | No       |
 | `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                              | `false`       | No       |
@@ -87,9 +87,9 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all        | -             | No       |
 | `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op) | `false`       | No       |
 
-### Read-only IMAP mode
+### IMAP-only mode (no SMTP)
 
-SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, the account runs in read-only mode and exposes only IMAP-backed tools. `send_email` is hidden when every configured email account is read-only; `save_to_mailbox` remains available since saving drafts/templates is a pure IMAP APPEND operation.
+SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, the account runs in IMAP-only mode: `send_email` is hidden (when every configured email account lacks SMTP) and no mail can leave the server. Note that IMAP-only is not strictly read-only — IMAP-backed write tools such as `save_to_mailbox` (which composes a message and stores it in a folder via IMAP APPEND), `delete_emails`, `move_emails`, and `archive_emails` remain available.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also configure the email server using environment variables, which is pa
 
 ### Read-only IMAP mode
 
-SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, the account runs in read-only mode and exposes only read/mailbox-management tools. Outbound compose tools such as `send_email` and `save_to_mailbox` are hidden when every configured email account is read-only.
+SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, the account runs in read-only mode and exposes only IMAP-backed tools. `send_email` is hidden when every configured email account is read-only; `save_to_mailbox` remains available since saving drafts/templates is a pure IMAP APPEND operation.
 
 ```json
 {

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -329,8 +329,8 @@ async def send_email(
 @mcp.tool(
     description="Compose an email and save it to an IMAP folder (e.g., Drafts). "
     "Same parameters as send_email, but saves instead of sending. "
-    "Default folder is Drafts with \\Draft and \\Seen flags.",
-    visible_if=_has_send_capable_account,
+    "Default folder is Drafts with \\Draft and \\Seen flags. "
+    "Pure IMAP operation — works without SMTP configuration.",
 )
 async def save_to_mailbox(
     account_name: Annotated[str, Field(description="The name of the email account.")],

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -234,8 +234,8 @@ async def get_emails_content(
 
 @mcp.tool(
     description=(
-        "List the configured outbound recipient allowlist — the addresses that send_email and "
-        "save_to_mailbox are permitted to send to. Only available when an allowlist is configured."
+        "List the configured recipient allowlist — the addresses that send_email is permitted to "
+        "send to and save_to_mailbox is permitted to address. Only available when an allowlist is configured."
     ),
     visible_if=_has_allowed_recipients,
 )

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1756,15 +1756,9 @@ class EmailClient:
 class ClassicEmailHandler(EmailHandler):
     def __init__(self, email_settings: EmailSettings):
         self.email_settings = email_settings
-        self.incoming_client = EmailClient(email_settings.incoming)
-        self.outgoing_client = (
-            EmailClient(
-                email_settings.outgoing,
-                sender=f"{email_settings.full_name} <{email_settings.email_address}>",
-            )
-            if email_settings.outgoing
-            else None
-        )
+        sender = f"{email_settings.full_name} <{email_settings.email_address}>"
+        self.incoming_client = EmailClient(email_settings.incoming, sender=sender)
+        self.outgoing_client = EmailClient(email_settings.outgoing, sender=sender) if email_settings.outgoing else None
         self.save_to_sent = email_settings.save_to_sent
         self.sent_folder_name = email_settings.sent_folder_name
 
@@ -1932,10 +1926,7 @@ class ClassicEmailHandler(EmailHandler):
             ValueError: If any flag in *flags* is invalid per RFC 3501.
             RuntimeError: If the IMAP APPEND operation fails.
         """
-        if self.outgoing_client is None:
-            raise RuntimeError(f"SMTP is not configured for account '{self.email_settings.account_name}'")
-
-        msg = self.outgoing_client.compose_message(
+        msg = self.incoming_client.compose_message(
             recipients,
             subject,
             body,
@@ -1950,7 +1941,7 @@ class ClassicEmailHandler(EmailHandler):
 
         flags_str = r"(\Draft \Seen)" if flags is None else _validate_flags(flags)
 
-        uid = await self.outgoing_client.append_to_mailbox(msg, self.email_settings.incoming, mailbox, flags_str)
+        uid = await self.incoming_client.append_to_mailbox(msg, self.email_settings.incoming, mailbox, flags_str)
 
         if uid is None:
             raise RuntimeError(f"Failed to save email to mailbox '{mailbox}'")

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -279,8 +279,8 @@ class TestClassicEmailHandler:
             )
 
     @pytest.mark.asyncio
-    async def test_read_only_account_rejects_save_to_mailbox(self):
-        """Read-only accounts cannot compose and save outbound drafts."""
+    async def test_read_only_account_can_save_to_mailbox(self):
+        """save_to_mailbox is a pure IMAP operation and works without SMTP."""
         email_settings = EmailSettings(
             account_name="read_only",
             full_name="Read Only",
@@ -294,13 +294,18 @@ class TestClassicEmailHandler:
             ),
         )
         handler = ClassicEmailHandler(email_settings)
+        mock_append = AsyncMock(return_value="42")
 
-        with pytest.raises(RuntimeError, match="SMTP is not configured"):
-            await handler.save_to_mailbox(
+        with patch.object(handler.incoming_client, "append_to_mailbox", mock_append):
+            result = await handler.save_to_mailbox(
                 recipients=["recipient@example.com"],
                 subject="Test Subject",
                 body="Test Body",
             )
+
+        assert "uid:42" in result
+        appended_msg = mock_append.call_args[0][0]
+        assert appended_msg["From"] == "Read Only <read-only@example.com>"
 
     @pytest.mark.asyncio
     async def test_delete_emails(self, classic_handler):

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -56,6 +56,7 @@ class TestClassicEmailHandler:
         assert handler.incoming_client.email_server == email_settings.incoming
         assert handler.outgoing_client.email_server == email_settings.outgoing
         assert handler.outgoing_client.sender == f"{email_settings.full_name} <{email_settings.email_address}>"
+        assert handler.incoming_client.sender == f"{email_settings.full_name} <{email_settings.email_address}>"
 
     def test_init_read_only_account(self):
         """Read-only accounts initialize without an outgoing SMTP client."""

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -376,7 +376,7 @@ class TestMcpTools:
 
     @pytest.mark.asyncio
     async def test_tool_visibility_hides_outbound_tools_for_read_only_accounts(self):
-        """Read-only deployments should hide outbound tools from MCP clients."""
+        """Read-only deployments hide send_email but keep IMAP-only tools like save_to_mailbox."""
         read_only_account = EmailSettings(
             account_name="read_only",
             full_name="Read Only",
@@ -396,7 +396,7 @@ class TestMcpTools:
             tool_names = {tool.name for tool in await app_module.mcp.list_tools()}
 
         assert "send_email" not in tool_names
-        assert "save_to_mailbox" not in tool_names
+        assert "save_to_mailbox" in tool_names
         assert "list_emails_metadata" in tool_names
         assert "get_emails_content" in tool_names
 

--- a/tests/test_save_to_mailbox.py
+++ b/tests/test_save_to_mailbox.py
@@ -498,6 +498,34 @@ class TestSaveToMailboxTool:
         assert "email_id: 42" in result
 
     @pytest.mark.asyncio
+    async def test_save_to_mailbox_tool_imap_only_account(self, monkeypatch, mock_imap):
+        """The MCP tool works end-to-end for an account without SMTP configuration."""
+        imap_only_settings = EmailSettings(
+            account_name="imap_only",
+            full_name="Imap Only",
+            email_address="imap-only@example.com",
+            incoming=EmailServer(**_INCOMING_SERVER),
+        )
+        handler = ClassicEmailHandler(imap_only_settings)
+        monkeypatch.setattr("mcp_email_server.app.dispatch_handler", lambda _: handler)
+        monkeypatch.setattr("mcp_email_server.app.get_settings", lambda: MagicMock(allowed_recipients=[]))
+
+        from mcp_email_server.app import save_to_mailbox
+
+        mock_imap.append = AsyncMock(return_value=("OK", [b"[APPENDUID 1234567890 7] APPEND completed"]))
+        with patch("mcp_email_server.emails.classic.aioimaplib") as mock_lib:
+            mock_lib.IMAP4_SSL.return_value = mock_imap
+            result = await save_to_mailbox(
+                account_name="imap_only",
+                recipients=["r@example.com"],
+                subject="Draft",
+                body="body",
+            )
+
+        assert "Drafts" in result
+        assert "email_id: 7" in result
+
+    @pytest.mark.asyncio
     async def test_save_to_mailbox_tool_custom_folder(self, monkeypatch):
         mock_handler = AsyncMock()
         mock_handler.save_to_mailbox = AsyncMock(return_value="<msg-id@example.com>|uid:99")

--- a/tests/test_save_to_mailbox.py
+++ b/tests/test_save_to_mailbox.py
@@ -353,8 +353,8 @@ class TestClassicEmailHandlerSaveToMailbox:
         mock_compose["Message-Id"] = "<test-id@example.com>"
         mock_append = AsyncMock(return_value="42")
 
-        with patch.object(handler.outgoing_client, "compose_message", return_value=mock_compose):
-            with patch.object(handler.outgoing_client, "append_to_mailbox", mock_append):
+        with patch.object(handler.incoming_client, "compose_message", return_value=mock_compose):
+            with patch.object(handler.incoming_client, "append_to_mailbox", mock_append):
                 result = await handler.save_to_mailbox(
                     recipients=["r@example.com"],
                     subject="Draft",
@@ -377,8 +377,8 @@ class TestClassicEmailHandlerSaveToMailbox:
         mock_compose["Message-Id"] = "<test-id@example.com>"
         mock_append = AsyncMock(return_value="99")
 
-        with patch.object(handler.outgoing_client, "compose_message", return_value=mock_compose):
-            with patch.object(handler.outgoing_client, "append_to_mailbox", mock_append):
+        with patch.object(handler.incoming_client, "compose_message", return_value=mock_compose):
+            with patch.object(handler.incoming_client, "append_to_mailbox", mock_append):
                 await handler.save_to_mailbox(
                     recipients=["r@example.com"],
                     subject="Template",
@@ -400,8 +400,8 @@ class TestClassicEmailHandlerSaveToMailbox:
         mock_compose = MIMEText("body")
         mock_append = AsyncMock(return_value=None)
 
-        with patch.object(handler.outgoing_client, "compose_message", return_value=mock_compose):
-            with patch.object(handler.outgoing_client, "append_to_mailbox", mock_append):
+        with patch.object(handler.incoming_client, "compose_message", return_value=mock_compose):
+            with patch.object(handler.incoming_client, "append_to_mailbox", mock_append):
                 with pytest.raises(RuntimeError, match="Failed to save email"):
                     await handler.save_to_mailbox(
                         recipients=["r@example.com"],
@@ -422,6 +422,33 @@ class TestClassicEmailHandlerSaveToMailbox:
             )
 
 
+class TestSaveToMailboxWithoutSmtp:
+    """save_to_mailbox is a pure IMAP operation — no SMTP configuration required."""
+
+    @pytest.mark.asyncio
+    async def test_imap_only_account_saves_successfully(self, mock_imap):
+        imap_only_settings = EmailSettings(
+            account_name="imap_only",
+            full_name="Imap Only",
+            email_address="imap-only@example.com",
+            incoming=EmailServer(**_INCOMING_SERVER),
+        )
+        handler = ClassicEmailHandler(imap_only_settings)
+        assert handler.outgoing_client is None
+
+        mock_imap.append = AsyncMock(return_value=("OK", [b"[APPENDUID 1234567890 7] APPEND completed"]))
+        with patch("mcp_email_server.emails.classic.aioimaplib") as mock_lib:
+            mock_lib.IMAP4_SSL.return_value = mock_imap
+            result = await handler.save_to_mailbox(
+                recipients=["r@example.com"],
+                subject="Draft",
+                body="draft body",
+            )
+
+        assert "uid:7" in result
+        mock_imap.select.assert_called_with('"Drafts"')
+
+
 class TestSaveToMailboxBcc:
     """Tests that save_to_mailbox preserves BCC in the saved message."""
 
@@ -432,7 +459,7 @@ class TestSaveToMailboxBcc:
 
         # Don't mock compose_message — let it run for real so we verify
         # include_bcc_header=True is actually passed and produces a Bcc header
-        with patch.object(handler.outgoing_client, "append_to_mailbox", mock_append):
+        with patch.object(handler.incoming_client, "append_to_mailbox", mock_append):
             await handler.save_to_mailbox(
                 recipients=["r@example.com"],
                 subject="Draft",


### PR DESCRIPTION
## Summary
- `save_to_mailbox` composes a message and stores it via IMAP APPEND — it never touches SMTP — but it was previously gated behind SMTP configuration in both tool visibility and the handler. This decouples it so IMAP-only accounts can save drafts/templates, while `send_email` still requires SMTP as before.
- `ClassicEmailHandler.save_to_mailbox` now routes through the incoming (IMAP) `EmailClient` instead of the outgoing (SMTP) one; the `RuntimeError("SMTP is not configured")` guard is removed for this tool only.
- Removed `visible_if=_has_send_capable_account` from the `save_to_mailbox` tool registration in `app.py`, matching every other IMAP-only tool (`delete_emails`, `move_emails`, `list_mailboxes`, ...).
- README's "read-only mode" section renamed to "IMAP-only mode" and clarified: it was never strictly read-only (delete/move/archive already worked), and now explicitly documents that `save_to_mailbox` is available too.
- The recipient allowlist (`MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`) still applies to `save_to_mailbox` unchanged.

## Test plan
- [x] `uv run pytest -q` — full suite passes (448 tests)
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Manual check: started the server with only IMAP env vars set (no `SMTP_HOST`) and confirmed via `mcp.list_tools()` that `save_to_mailbox` is listed while `send_email` is not
- [x] Independent adversarial code review pass (no correctness issues; addressed the doc/test-coverage findings in a follow-up commit on this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)