### PR TITLE
fix: restrict credentials config file to owner-only permissions

### DIFF
--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -397,7 +397,18 @@ class Settings(BaseSettings):
     def store(self) -> None:
         toml_file = self.model_config["toml_file"]
         toml_file.parent.mkdir(parents=True, exist_ok=True)
-        toml_file.write_text(self._to_toml())
+        content = self._to_toml()
+        if os.name == "posix":
+            # Create with owner-only permissions from the start (contains cleartext
+            # IMAP/SMTP passwords), so there's no window where the file is world-readable.
+            # os.O_CREAT only applies the mode on creation, so chmod explicitly to also
+            # cover the case where the file already existed with looser permissions.
+            fd = os.open(toml_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            toml_file.chmod(0o600)
+        else:
+            toml_file.write_text(content)
         logger.info(f"Settings stored in {toml_file}")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,6 +306,23 @@ def test_store_tightens_preexisting_permissions(tmp_path, monkeypatch):
         config_module._settings = None
 
 
+def test_store_non_posix_falls_back_to_plain_write(tmp_path, monkeypatch):
+    """On non-POSIX platforms store() writes via write_text (no fd-level permissions)."""
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        settings = config_module.get_settings(reload=True)
+        monkeypatch.setattr(config_module.os, "name", "nt")
+        settings.store()
+        assert cfg.read_text() == settings._to_toml()
+    finally:
+        config_module._settings = None
+
+
 def test_report_blocked_mutations_env_overrides_toml(tmp_path, monkeypatch):
     import tomli_w
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+import stat
+import sys
+
 import pytest
 from pydantic import SecretStr, ValidationError
 
@@ -261,6 +264,44 @@ def test_report_blocked_mutations_from_toml(tmp_path, monkeypatch):
     config_module._settings = None
     try:
         assert config_module.get_settings(reload=True).report_blocked_mutations is True
+    finally:
+        config_module._settings = None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permissions only")
+def test_store_writes_owner_only_permissions(tmp_path, monkeypatch):
+    """The stored config contains cleartext credentials, so it must not be world/group readable."""
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        settings = config_module.get_settings(reload=True)
+        settings.store()
+        mode = stat.S_IMODE(cfg.stat().st_mode)
+        assert mode == 0o600
+    finally:
+        config_module._settings = None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permissions only")
+def test_store_tightens_preexisting_permissions(tmp_path, monkeypatch):
+    """A pre-existing world-readable file must be tightened, not left as-is."""
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("")
+    cfg.chmod(0o644)
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        settings = config_module.get_settings(reload=True)
+        settings.store()
+        mode = stat.S_IMODE(cfg.stat().st_mode)
+        assert mode == 0o600
     finally:
         config_module._settings = None
 


### PR DESCRIPTION
## Summary
- `Settings.store()` wrote the plaintext credentials TOML file (which contains cleartext IMAP/SMTP passwords via `EmailServer.password.get_secret_value()`) using the process's default umask — typically `0o644` on Linux/macOS, making it readable by any other local user on a shared machine.
- Writes now happen via `os.open(..., 0o600)` on POSIX so the file is owner-only from creation, and a following `chmod(0o600)` also tightens any pre-existing file that had looser permissions. Non-POSIX platforms (Windows) fall back to the previous `write_text` behavior.

## Test plan
- [x] Added `test_store_writes_owner_only_permissions` and `test_store_tightens_preexisting_permissions` in `tests/test_config.py` (skipped on Windows)
- [x] `uv run pytest -q` — 448 passed
- [x] `uv run ruff check mcp_email_server/config.py tests/test_config.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)