### PR TITLE
feat: OS keyring credential storage with plaintext TOML fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,63 @@ This package is available on PyPI, so you can install it using `pip install mcp-
 
 After that, configure your email server using the ui: `mcp-email-server ui`
 
+### Credential Storage
+
+Accounts added via the UI or the `add_email_account` tool are persisted to a TOML
+file at `~/.config/zerolib/mcp_email_server/config.toml`. Where the actual
+passwords/API keys live depends on `credential_storage` (also settable via
+`MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`), one of:
+
+- **`auto`** (default): store credentials in the OS keyring — macOS Keychain,
+  Linux Secret Service (GNOME Keyring / KWallet) — when a usable backend is
+  detected; otherwise fall back to the plaintext TOML file (`0o600`
+  permissions, owner-only). Falls back automatically on headless Linux,
+  Docker, or any environment without a D-Bus session.
+- **`keyring`**: require the OS keyring; fail loudly instead of silently
+  falling back if no backend is usable.
+- **`plaintext`**: never touch the keyring. Useful for containers, CI, or if
+  you simply prefer a portable config file.
+
+When credentials are keyring-backed, the TOML file stores only a placeholder
+(`__KEYRING__`) and non-secret metadata — the real secret lives in the OS
+keyring under service `mcp-email-server`, one entry per
+`<account_name>:<incoming|outgoing|api_key>` (viewable in Keychain Access on
+macOS, or Seahorse on Linux).
+
+**Migrating an existing config** between storage modes:
+
+```sh
+mcp-email-server migrate-credentials --to keyring    # move plaintext secrets into the OS keyring
+mcp-email-server migrate-credentials --to plaintext  # move keyring secrets back into the TOML file
+```
+
+Migration also happens implicitly: any time you add/edit an account while
+`credential_storage` is `auto` or `keyring` with a usable backend, that
+account's secrets move into the keyring on the next save.
+
+#### Failure modes & troubleshooting
+
+- **Server won't start / UI won't load accounts, keychain-related error**: the
+  OS keyring is locked or unreachable. This is expected if credentials are
+  keyring-backed — the secret simply isn't in the config file. Unlock your
+  keychain, or run `mcp-email-server migrate-credentials --to plaintext` if
+  you'd rather not depend on it.
+- **`credential_storage` is 'plaintext' but the config references
+  keyring-stored credentials**: run `migrate-credentials --to plaintext`, or
+  unset `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` / the `credential_storage`
+  setting so the config can resolve them from the keyring instead.
+- **macOS Keychain access prompt, or the server can't read a secret it wrote
+  earlier**: Keychain ACLs are per-application. If the server is spawned via
+  `uvx` (as in the Claude Desktop config above), a fresh `uvx` resolution can
+  present a different binary path than the one that stored the secret,
+  triggering a "Keychain wants to use a password" prompt. Choose "Always
+  Allow" the first time this happens.
+- **A migration seems to have had no effect**: if
+  `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is set in your environment, it takes
+  precedence over whatever `migrate-credentials --to ...` just wrote to the
+  file on every subsequent run. Unset it, or keep it in sync with your
+  intended mode.
+
 ### Environment Variable Configuration
 
 You can also configure the email server using environment variables, which is particularly useful for CI/CD environments like Jenkins. zerolib-email supports both UI configuration (via TOML file) and environment variables, with environment variables taking precedence.
@@ -86,6 +143,7 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all           | -             | No       |
 | `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all        | -             | No       |
 | `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op) | `false`       | No       |
+| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`   | `auto`        | No       |
 
 ### Read-only IMAP mode
 

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -10,6 +10,7 @@ from mcp_email_server.config import (
     AccountAttributes,
     EmailSettings,
     ProviderSettings,
+    clear_settings_cache,
     get_settings,
     normalize_address,
 )
@@ -104,7 +105,14 @@ async def list_available_accounts() -> list[AccountAttributes]:
 async def add_email_account(email: EmailSettings) -> str:
     settings = get_settings()
     settings.add_email(email)
-    settings.store()
+    try:
+        settings.store()
+    except Exception:
+        # settings.add_email() already mutated the cached instance above; if store()
+        # fails (e.g. a locked keychain in explicit keyring mode), discard the cache
+        # so later tool calls don't see a phantom account that isn't actually on disk.
+        clear_settings_cache()
+        raise
     return f"Successfully added email account '{email.account_name}'"
 
 

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -104,13 +104,16 @@ async def list_available_accounts() -> list[AccountAttributes]:
 @mcp.tool(description="Add a new email account configuration to the settings.")
 async def add_email_account(email: EmailSettings) -> str:
     settings = get_settings()
-    settings.add_email(email)
     try:
+        settings.add_email(email)
         settings.store()
     except Exception:
-        # settings.add_email() already mutated the cached instance above; if store()
-        # fails (e.g. a locked keychain in explicit keyring mode), discard the cache
-        # so later tool calls don't see a phantom account that isn't actually on disk.
+        # add_email() reassigns settings.emails, and pydantic's validate_assignment
+        # applies the new value BEFORE running the check_unique_account_names
+        # after-validator — so even a rejected duplicate-name add leaves the cached
+        # instance mutated. store() can also mutate-then-fail (e.g. a locked
+        # keychain in explicit keyring mode). Either way, discard the cache so later
+        # tool calls don't see a phantom/corrupted account that isn't actually on disk.
         clear_settings_cache()
         raise
     return f"Successfully added email account '{email.account_name}'"

--- a/mcp_email_server/cli.py
+++ b/mcp_email_server/cli.py
@@ -1,12 +1,20 @@
+import enum
 import os
 
 import typer
 from mcp.server.transport_security import TransportSecuritySettings
 
 from mcp_email_server.app import mcp
-from mcp_email_server.config import delete_settings
+from mcp_email_server.config import Settings, delete_settings
+from mcp_email_server.keyring_store import delete_account_credentials
 
 app = typer.Typer()
+
+
+class CredentialStorageTarget(str, enum.Enum):
+    keyring = "keyring"
+    plaintext = "plaintext"
+
 
 LOOPBACK_ALLOWED_HOSTS = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
 LOOPBACK_ALLOWED_ORIGINS = ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
@@ -147,6 +155,59 @@ def ui():
 def reset():
     delete_settings()
     typer.echo("✅ Config reset")
+
+
+@app.command(name="migrate-credentials")
+def migrate_credentials(
+    to: CredentialStorageTarget = typer.Option(  # noqa: B008 (standard typer idiom)
+        CredentialStorageTarget.keyring, "--to", help="Target credential storage mode."
+    ),
+) -> None:
+    """Move all stored credentials to the OS keyring or to the plaintext config file.
+
+    Loads the config bypassing env-composited state (env-var accounts, allowlist/bool
+    overrides), so migration transforms the stored config, not the env-overridden view.
+    """
+    target = to.value
+
+    env_override = os.environ.get("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE")
+    if env_override is not None and env_override != target:
+        typer.echo(
+            f"Warning: MCP_EMAIL_SERVER_CREDENTIAL_STORAGE={env_override!r} is set and differs "
+            f"from --to {target!r}. This migration will still write '{target}', but future runs "
+            "will keep obeying the environment variable until it's unset.",
+            err=True,
+        )
+
+    try:
+        settings = Settings.load_for_migration()
+    except Exception as e:
+        typer.echo(f"Error: could not load the current configuration: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    settings.credential_storage = target
+    settings._credential_storage_override = target
+
+    try:
+        settings.store()
+    except Exception as e:
+        typer.echo(f"Error: migration to '{target}' failed: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    if target == "plaintext":
+        # Live secrets would otherwise sit in the keyring forever after a permanent
+        # migration away from it; this is the one sanctioned exception to "plaintext
+        # mode never touches the keyring" since it's explicit and user-invoked.
+        for email in settings.emails:
+            roles = ["incoming"]
+            if email.outgoing:
+                roles.append("outgoing")
+            delete_account_credentials(email.account_name, roles)
+        for provider in settings.providers:
+            delete_account_credentials(provider.account_name, ["api_key"])
+
+    total = len(settings.emails) + len(settings.providers)
+    typer.echo(f"✅ Migrated {total} account(s) to '{target}' storage")
 
 
 if __name__ == "__main__":

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -397,7 +397,18 @@ class Settings(BaseSettings):
     def store(self) -> None:
         toml_file = self.model_config["toml_file"]
         toml_file.parent.mkdir(parents=True, exist_ok=True)
-        toml_file.write_text(self._to_toml())
+        content = self._to_toml()
+        if os.name == "posix":
+            # Create with owner-only permissions from the start (contains cleartext
+            # IMAP/SMTP passwords), so there's no window where the file is world-readable.
+            # os.O_CREAT only applies the mode on creation, so chmod explicitly to also
+            # cover the case where the file already existed with looser permissions.
+            fd = os.open(toml_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            toml_file.chmod(0o600)
+        else:
+            toml_file.write_text(content)
         logger.info(f"Settings stored in {toml_file}")
 
 

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -25,7 +25,7 @@ from mcp_email_server.log import logger
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib
+    import tomli as tomllib  # pragma: no cover (coverage is uploaded from the 3.12 job)
 
 DEFAULT_CONFIG_PATH = "~/.config/zerolib/mcp_email_server/config.toml"
 _VALID_CREDENTIAL_STORAGE_MODES = ("auto", "keyring", "plaintext")

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import datetime
 import fnmatch
 import os
+import sys
 from collections.abc import Iterable
 from email.utils import getaddresses, parseaddr
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
 import tomli_w
-from pydantic import BaseModel, Field, SecretStr, field_serializer, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, SecretStr, SerializationInfo, field_serializer, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -18,9 +19,21 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
+from mcp_email_server import keyring_store
 from mcp_email_server.log import logger
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 DEFAULT_CONFIG_PATH = "~/.config/zerolib/mcp_email_server/config.toml"
+_VALID_CREDENTIAL_STORAGE_MODES = ("auto", "keyring", "plaintext")
+
+# Set by Settings.load_for_migration() around construction so __init__ can skip
+# env-composited state (override pickup, env-account injection, allowlist/bool env
+# reads) and always attempt keyring resolution regardless of credential_storage.
+_MIGRATION_LOAD = False
 
 
 def _parse_bool_env(value: str | None, default: bool = False) -> bool:
@@ -66,6 +79,22 @@ def _normalize_pattern_list(raw: Iterable[str]) -> list[str]:
     return list(dict.fromkeys(p.strip().lower() for p in raw if p.strip()))
 
 
+def _reject_sentinel_secret(secret: SecretStr, label: str) -> None:
+    """Reject the reserved keyring sentinel as a literal secret value.
+
+    Cannot be enforced with a field validator on EmailServer/ProviderSettings:
+    those run during the TOML load itself, before any Settings-level code, and
+    would reject every legitimately keyring-stored config. Enforced instead at
+    creation entry points (EmailSettings.init, Settings.add_email/add_provider)
+    and as a defense-in-depth pre-write check in Settings.store().
+    """
+    if secret.get_secret_value() == keyring_store.SENTINEL:
+        raise ValueError(
+            f"{label} cannot be the reserved value {keyring_store.SENTINEL!r} "
+            "(used internally to mark keyring-stored credentials)"
+        )
+
+
 CONFIG_PATH = Path(os.getenv("MCP_EMAIL_SERVER_CONFIG_PATH", DEFAULT_CONFIG_PATH)).expanduser().resolve()
 
 
@@ -79,7 +108,9 @@ class EmailServer(BaseModel):
     verify_ssl: bool = True  # Set to False for self-signed certificates (e.g., ProtonMail Bridge)
 
     @field_serializer("password")
-    def serialize_password(self, v: SecretStr) -> str:
+    def serialize_password(self, v: SecretStr, info: SerializationInfo) -> str:
+        if info.context and info.context.get("secrets") == "keyring":
+            return keyring_store.SENTINEL
         return v.get_secret_value()
 
     def masked(self) -> EmailServer:
@@ -152,6 +183,12 @@ class EmailSettings(AccountAttributes):
         save_to_sent: bool = True,
         sent_folder_name: str | None = None,
     ) -> EmailSettings:
+        for candidate in (password, imap_password, smtp_password):
+            if candidate == keyring_store.SENTINEL:
+                raise ValueError(
+                    f"Password value {keyring_store.SENTINEL!r} is reserved for keyring-stored "
+                    "credentials and cannot be used as an account password"
+                )
         return cls(
             account_name=account_name,
             full_name=full_name,
@@ -266,7 +303,9 @@ class ProviderSettings(AccountAttributes):
     api_key: SecretStr
 
     @field_serializer("api_key")
-    def serialize_api_key(self, v: SecretStr) -> str:
+    def serialize_api_key(self, v: SecretStr, info: SerializationInfo) -> str:
+        if info.context and info.context.get("secrets") == "keyring":
+            return keyring_store.SENTINEL
         return v.get_secret_value()
 
     def masked(self) -> AccountAttributes:
@@ -281,8 +320,23 @@ class Settings(BaseSettings):
     allowed_recipients: list[str] = []
     allowed_senders: list[str] = []
     report_blocked_mutations: bool = False
+    credential_storage: Literal["auto", "keyring", "plaintext"] = "auto"
+
+    # Env-var override for credential_storage. Kept off the persisted field so a
+    # later store() never bakes a temporary override into the TOML (unlike the
+    # bool overrides below, which intentionally do persist).
+    _credential_storage_override: str | None = PrivateAttr(default=None)
 
     model_config = SettingsConfigDict(toml_file=CONFIG_PATH, validate_assignment=True, revalidate_instances="always")
+
+    @property
+    def effective_credential_storage(self) -> str:
+        """The mode that actually governs storage decisions: env override, else the field.
+
+        Returns the raw three-value literal — never probes the keyring. Only
+        store() maps "auto" to a concrete backend via keyring_store.keyring_usable().
+        """
+        return self._credential_storage_override or self.credential_storage
 
     def _apply_bool_env_override(self, attr: str, env_var: str) -> None:
         value = os.getenv(env_var)
@@ -290,56 +344,147 @@ class Settings(BaseSettings):
             setattr(self, attr, _parse_bool_env(value, False))
             logger.info(f"Set {attr}={getattr(self, attr)} from environment variable")
 
+    def _pickup_credential_storage_override(self) -> None:
+        override = os.getenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE")
+        if override is None:
+            return
+        if override not in _VALID_CREDENTIAL_STORAGE_MODES:
+            raise ValueError(
+                f"Invalid MCP_EMAIL_SERVER_CREDENTIAL_STORAGE={override!r}; "
+                f"must be one of {', '.join(_VALID_CREDENTIAL_STORAGE_MODES)}"
+            )
+        self._credential_storage_override = override
+
     def __init__(self, **data: Any) -> None:
         """Initialize Settings with support for environment variables."""
         super().__init__(**data)
 
-        self._apply_bool_env_override("enable_attachment_download", "MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD")
-        self._apply_bool_env_override("report_blocked_mutations", "MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS")
+        migration_load = _MIGRATION_LOAD
 
-        # Normalise allowed_recipients from TOML (bare, lowercased, de-duplicated)
+        # TOML normalisation is unconditional (safe during migration loads too): it
+        # only reshapes values already in the file, independent of env state.
         if self.allowed_recipients:
             self.allowed_recipients = _normalize_address_list(self.allowed_recipients)
+        if self.allowed_senders:
+            self.allowed_senders = _normalize_pattern_list(self.allowed_senders)
+
+        if not migration_load:
+            self._apply_env_overrides()
+
+        # Sentinel resolution always runs (including migration loads); only the
+        # plaintext-mode hard error is suppressed during migration (§2/§5/§7).
+        self._resolve_keyring_sentinels(migration_load=migration_load)
+
+    def _apply_env_overrides(self) -> None:
+        """Env-composited state, skipped entirely during migration loads (§7) so
+        migration transforms the stored config, not the env-composited view.
+        """
+        self._pickup_credential_storage_override()
+        self._apply_bool_env_override("enable_attachment_download", "MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD")
+        self._apply_bool_env_override("report_blocked_mutations", "MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS")
 
         # Environment variable overrides TOML (comma-separated); an empty string clears the allowlist.
         env_allowed = os.getenv("MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS")
         if env_allowed is not None:
             self.allowed_recipients = _normalize_address_list(env_allowed.split(","))
 
-        # Normalise allowed_senders from TOML (lowercased, de-duplicated; globs preserved)
-        if self.allowed_senders:
-            self.allowed_senders = _normalize_pattern_list(self.allowed_senders)
-
-        # Environment variable overrides TOML (comma-separated); an empty string clears the allowlist.
         env_senders = os.getenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS")
         if env_senders is not None:
             self.allowed_senders = _normalize_pattern_list(env_senders.split(","))
 
-        # Check for email configuration from environment variables
-        env_email = EmailSettings.from_env()
-        if env_email:
-            # Check if this account already exists (from TOML)
-            existing_account = None
-            for i, email in enumerate(self.emails):
-                if email.account_name == env_email.account_name:
-                    existing_account = i
-                    break
+        self._inject_env_account()
 
-            if existing_account is not None:
-                # Replace existing account with env configuration
-                self.emails[existing_account] = env_email
-                logger.info(f"Overriding email account '{env_email.account_name}' with environment variables")
-            else:
-                # Add new account from env
-                self.emails.insert(0, env_email)
-                logger.info(f"Added email account '{env_email.account_name}' from environment variables")
+    def _inject_env_account(self) -> None:
+        env_email = EmailSettings.from_env()
+        if not env_email:
+            return
+
+        existing_account = None
+        for i, email in enumerate(self.emails):
+            if email.account_name == env_email.account_name:
+                existing_account = i
+                break
+
+        if existing_account is not None:
+            self.emails[existing_account] = env_email
+            logger.info(f"Overriding email account '{env_email.account_name}' with environment variables")
+        else:
+            self.emails.insert(0, env_email)
+            logger.info(f"Added email account '{env_email.account_name}' from environment variables")
+
+    def _pending_keyring_sentinels(self) -> list[tuple[str, str, EmailServer | ProviderSettings]]:
+        pending: list[tuple[str, str, EmailServer | ProviderSettings]] = []
+        for email in self.emails:
+            if email.incoming.password.get_secret_value() == keyring_store.SENTINEL:
+                pending.append((email.account_name, "incoming", email.incoming))
+            if email.outgoing and email.outgoing.password.get_secret_value() == keyring_store.SENTINEL:
+                pending.append((email.account_name, "outgoing", email.outgoing))
+        for provider in self.providers:
+            if provider.api_key.get_secret_value() == keyring_store.SENTINEL:
+                pending.append((provider.account_name, "api_key", provider))
+        return pending
+
+    def _resolve_keyring_sentinels(self, *, migration_load: bool) -> None:
+        pending = self._pending_keyring_sentinels()
+        if not pending:
+            return
+
+        if not migration_load and self.effective_credential_storage == "plaintext":
+            names = ", ".join(sorted({name for name, _role, _obj in pending}))
+            raise ValueError(
+                f"Account(s) {names} reference keyring-stored credentials but credential_storage "
+                "is 'plaintext'. Run `mcp-email-server migrate-credentials --to plaintext` to "
+                "convert them, or unset MCP_EMAIL_SERVER_CREDENTIAL_STORAGE / the credential_storage "
+                "setting."
+            )
+
+        for account_name, role, obj in pending:
+            self._resolve_one_sentinel(account_name, role, obj)
+
+    @staticmethod
+    def _resolve_one_sentinel(account_name: str, role: str, obj: EmailServer | ProviderSettings) -> None:
+        try:
+            value = keyring_store.get_secret(account_name, role)
+        except Exception:
+            value = None
+        if value is None:
+            raise ValueError(
+                f"Could not resolve credential for account '{account_name}' ({role}) from the OS "
+                f"keyring (service '{keyring_store.SERVICE}', entry '{account_name}:{role}'). Re-add "
+                "the account, restore access to your OS keyring, or check for a Keychain access "
+                "prompt/ACL denial if the server binary changed (e.g. uvx re-resolution)."
+            )
+        secret = SecretStr(value)
+        if role == "api_key":
+            obj.api_key = secret
+        else:
+            obj.password = secret
+
+    @classmethod
+    def load_for_migration(cls) -> Settings:
+        """Load ignoring env-composited state, so migration transforms the stored config only.
+
+        Skips the credential_storage env override, env-account injection, and the
+        bool/allowlist env reads; suppresses the plaintext-sentinel load error so
+        sentinels always resolve via keyring regardless of the file's mode.
+        """
+        global _MIGRATION_LOAD
+        _MIGRATION_LOAD = True
+        try:
+            return cls()
+        finally:
+            _MIGRATION_LOAD = False
 
     def add_email(self, email: EmailSettings) -> None:
         """Use re-assigned for validation to work."""
+        _reject_sentinel_secret(email.incoming.password, "incoming password")
+        if email.outgoing:
+            _reject_sentinel_secret(email.outgoing.password, "outgoing password")
         self.emails = [email, *self.emails]
 
     def add_provider(self, provider: ProviderSettings) -> None:
         """Use re-assigned for validation to work."""
+        _reject_sentinel_secret(provider.api_key, "api_key")
         self.providers = [provider, *self.providers]
 
     def delete_email(self, account_name: str) -> None:
@@ -390,26 +535,88 @@ class Settings(BaseSettings):
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         return (TomlConfigSettingsSource(settings_cls),)
 
-    def _to_toml(self) -> str:
-        data = self.model_dump(exclude_none=True)
+    def _to_toml(self, *, use_keyring: bool = False) -> str:
+        context = {"secrets": "keyring"} if use_keyring else None
+        data = self.model_dump(exclude_none=True, context=context)
         return tomli_w.dumps(data)
 
-    def store(self) -> None:
-        toml_file = self.model_config["toml_file"]
-        toml_file.parent.mkdir(parents=True, exist_ok=True)
-        content = self._to_toml()
+    def _reject_cleartext_sentinels(self) -> None:
+        """Defense-in-depth: catches sentinel values that bypassed add_email/add_provider
+        (e.g. direct ``settings.emails.append(...)``) before they'd be written as a literal
+        cleartext password.
+        """
+        for email in self.emails:
+            _reject_sentinel_secret(email.incoming.password, f"'{email.account_name}' incoming password")
+            if email.outgoing:
+                _reject_sentinel_secret(email.outgoing.password, f"'{email.account_name}' outgoing password")
+        for provider in self.providers:
+            _reject_sentinel_secret(provider.api_key, f"'{provider.account_name}' api_key")
+
+    def _store_secrets_to_keyring(self) -> list[tuple[str, str, str]]:
+        """Push every secret to the keyring; returns (account_name, role, error) for failures."""
+        failures: list[tuple[str, str, str]] = []
+        for email in self.emails:
+            for role, server in (("incoming", email.incoming), ("outgoing", email.outgoing)):
+                if server is None:
+                    continue
+                try:
+                    keyring_store.set_secret(email.account_name, role, server.password.get_secret_value())
+                except Exception as e:
+                    failures.append((email.account_name, role, str(e)))
+        for provider in self.providers:
+            try:
+                keyring_store.set_secret(provider.account_name, "api_key", provider.api_key.get_secret_value())
+            except Exception as e:
+                failures.append((provider.account_name, "api_key", str(e)))
+        return failures
+
+    @staticmethod
+    def _write_toml(toml_file: Path, content: str) -> None:
         if os.name == "posix":
             # Create with owner-only permissions from the start (contains cleartext
-            # IMAP/SMTP passwords), so there's no window where the file is world-readable.
-            # os.O_CREAT only applies the mode on creation, so chmod explicitly to also
-            # cover the case where the file already existed with looser permissions.
+            # IMAP/SMTP passwords in plaintext mode), so there's no window where the
+            # file is world-readable. os.O_CREAT only applies the mode on creation, so
+            # chmod explicitly to also cover the case where the file already existed
+            # with looser permissions.
             fd = os.open(toml_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             with os.fdopen(fd, "w") as f:
                 f.write(content)
             toml_file.chmod(0o600)
         else:
             toml_file.write_text(content)
-        logger.info(f"Settings stored in {toml_file}")
+
+    def store(self) -> None:
+        toml_file = self.model_config["toml_file"]
+        toml_file.parent.mkdir(parents=True, exist_ok=True)
+
+        effective = self.effective_credential_storage  # raw literal; never probes
+        auto_probe_usable = effective == "auto" and keyring_store.keyring_usable()
+        use_keyring = effective == "keyring" or auto_probe_usable
+
+        if use_keyring:
+            failures = self._store_secrets_to_keyring()
+            if failures:
+                if effective == "keyring":
+                    detail = "; ".join(f"{name}:{role} ({err})" for name, role, err in failures)
+                    raise ValueError(f"Failed to store credential(s) in the OS keyring: {detail}")
+                logger.warning(
+                    f"Keyring store failed for {len(failures)} credential(s) in auto mode; "
+                    "falling back to plaintext for this write"
+                )
+                use_keyring = False
+        elif effective == "auto":
+            logger.warning(
+                "No usable OS keyring backend detected; storing credentials in plaintext. Set "
+                "MCP_EMAIL_SERVER_CREDENTIAL_STORAGE=keyring to require the keyring, or 'plaintext' "
+                "to silence this warning."
+            )
+
+        if not use_keyring:
+            self._reject_cleartext_sentinels()
+
+        content = self._to_toml(use_keyring=use_keyring)
+        self._write_toml(toml_file, content)
+        logger.info(f"Settings stored in {toml_file} ({'keyring' if use_keyring else 'plaintext'})")
 
 
 _settings = None
@@ -423,15 +630,74 @@ def get_settings(reload: bool = False) -> Settings:
     return _settings
 
 
+def clear_settings_cache() -> None:
+    """Discard the cached Settings instance.
+
+    Used after a failed store() to stop a divergent in-memory instance (one that
+    was mutated before the store raised) from being served by a later
+    get_settings() call. get_settings(reload=True) alone is NOT equivalent: if the
+    reload itself raises (e.g. a locked keychain plus a sentinel-bearing file — the
+    same failure that made store() raise), get_settings keeps the old divergent
+    instance rather than discarding it.
+    """
+    global _settings
+    _settings = None
+
+
 def store_settings(settings: Settings | None = None) -> None:
     if not settings:
         settings = get_settings()
     settings.store()
 
 
+def _reset_cleanup_mode(raw: dict[str, Any]) -> str:
+    override = os.getenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE")
+    if override is not None:
+        if override in _VALID_CREDENTIAL_STORAGE_MODES:
+            return override
+        logger.warning(
+            f"Invalid MCP_EMAIL_SERVER_CREDENTIAL_STORAGE={override!r} while cleaning up keyring "
+            "entries during reset; proceeding as if it were unset"
+        )
+    toml_mode = raw.get("credential_storage", "auto")
+    return toml_mode if toml_mode in _VALID_CREDENTIAL_STORAGE_MODES else "auto"
+
+
+def _cleanup_keyring_entries_for_reset() -> None:
+    """Best-effort keyring cleanup for delete_settings(); must never raise.
+
+    Deliberately does NOT construct Settings(): that would hard-fail on sentinel
+    resolution exactly when the user's keyring is broken (the scenario `reset` is
+    the escape hatch for) and would trigger unwanted side effects (env-account
+    injection, env overrides). Parses the raw TOML instead.
+    """
+    try:
+        raw = tomllib.loads(CONFIG_PATH.read_text())
+        if _reset_cleanup_mode(raw) == "plaintext":
+            return
+        for email in raw.get("emails", []):
+            name = email.get("account_name")
+            if not name:
+                continue
+            roles = ["incoming"]
+            if email.get("outgoing"):
+                roles.append("outgoing")
+            keyring_store.delete_account_credentials(name, roles)
+        for provider in raw.get("providers", []):
+            name = provider.get("account_name")
+            if name:
+                keyring_store.delete_account_credentials(name, ["api_key"])
+    except Exception as e:
+        logger.warning(
+            f"Could not clean up keyring entries for {CONFIG_PATH}: {e}; some entries may remain "
+            f"under service '{keyring_store.SERVICE}'"
+        )
+
+
 def delete_settings() -> None:
     if not CONFIG_PATH.exists():
         logger.info(f"Settings file {CONFIG_PATH} does not exist")
         return
+    _cleanup_keyring_entries_for_reset()
     CONFIG_PATH.unlink()
     logger.info(f"Deleted settings file {CONFIG_PATH}")

--- a/mcp_email_server/keyring_store.py
+++ b/mcp_email_server/keyring_store.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from functools import lru_cache
+
+from mcp_email_server.log import logger
+
+SERVICE = "mcp-email-server"
+SENTINEL = "__KEYRING__"
+
+
+def _entry_key(account_name: str, role: str) -> str:
+    return f"{account_name}:{role}"
+
+
+@lru_cache(maxsize=1)
+def keyring_usable() -> bool:
+    """Probe the active keyring backend with a real set/get round-trip.
+
+    A locked collection or denied prompt can make ``get_keyring()`` look
+    usable while every operation actually fails, so only a live round-trip is
+    trustworthy. Cached for the process lifetime: a keychain locked at first
+    probe keeps the process on plaintext until restart.
+    """
+    import keyring
+
+    probe_key = f"__probe__{os.getpid()}"
+    try:
+        keyring.set_password(SERVICE, probe_key, "ok")
+        ok = keyring.get_password(SERVICE, probe_key) == "ok"
+    except Exception:
+        return False
+
+    try:
+        keyring.delete_password(SERVICE, probe_key)
+    except Exception:
+        logger.debug("Keyring probe cleanup failed; leftover probe entry is harmless")
+
+    if ok:
+        logger.info(f"Keyring backend usable: {keyring.get_keyring()}")
+    return ok
+
+
+def set_secret(account_name: str, role: str, value: str) -> None:
+    import keyring
+
+    keyring.set_password(SERVICE, _entry_key(account_name, role), value)
+
+
+def get_secret(account_name: str, role: str) -> str | None:
+    import keyring
+
+    return keyring.get_password(SERVICE, _entry_key(account_name, role))
+
+
+def delete_secret(account_name: str, role: str) -> None:
+    """Best-effort delete: swallows missing-entry and missing-backend errors alike."""
+    import keyring
+    from keyring.errors import KeyringError
+
+    try:
+        keyring.delete_password(SERVICE, _entry_key(account_name, role))
+    except KeyringError:
+        logger.debug(f"Keyring delete for '{account_name}:{role}' failed (already absent or no backend)")
+
+
+def delete_account_credentials(account_name: str, roles: Iterable[str]) -> None:
+    """Best-effort cleanup of every keyring entry for an account being removed."""
+    for role in roles:
+        delete_secret(account_name, role)

--- a/mcp_email_server/ui.py
+++ b/mcp_email_server/ui.py
@@ -1,6 +1,7 @@
 import gradio as gr
 
-from mcp_email_server.config import EmailSettings, get_settings, store_settings
+from mcp_email_server.config import EmailSettings, clear_settings_cache, get_settings, store_settings
+from mcp_email_server.keyring_store import delete_account_credentials
 from mcp_email_server.tools.installer import install_claude_desktop, is_installed, need_update, uninstall_claude_desktop
 
 
@@ -11,13 +12,26 @@ def create_ui():  # noqa: C901
 
         # Function to get current accounts
         def get_current_accounts():
-            settings = get_settings(reload=True)
+            try:
+                settings = get_settings(reload=True)
+            except Exception:
+                return []
             email_accounts = [email.account_name for email in settings.emails]
             return email_accounts
 
         # Function to update account list display
         def update_account_list():
-            settings = get_settings(reload=True)
+            try:
+                settings = get_settings(reload=True)
+            except Exception as e:
+                # A sentinel-bearing config with a broken/locked keyring (or a
+                # lingering plaintext override) would otherwise crash the UI at
+                # exactly the moment a user reaches for it to fix their accounts.
+                return (
+                    f"## Error loading accounts\n\n{e!s}",
+                    gr.update(choices=[], value=None),
+                    gr.update(visible=False),
+                )
             email_accounts = [email.account_name for email in settings.emails]
 
             if email_accounts:
@@ -78,15 +92,37 @@ def create_ui():  # noqa: C901
                     # Get current settings
                     settings = get_settings()
 
+                    # Capture which keyring roles this account may have used before it's gone
+                    deleted = settings.get_account(account_name)
+                    roles = []
+                    if deleted is not None and hasattr(deleted, "incoming"):
+                        roles.append("incoming")
+                        if deleted.outgoing:
+                            roles.append("outgoing")
+                    elif deleted is not None:
+                        roles.append("api_key")
+
                     # Delete the account
                     settings.delete_email(account_name)
 
                     # Store settings
                     store_settings(settings)
 
+                    # Best-effort keyring cleanup now that the file no longer references it.
+                    # Gated on the effective mode: plaintext mode must never touch the keyring,
+                    # even if a real backend happens to be available on this machine.
+                    if settings.effective_credential_storage != "plaintext":
+                        delete_account_credentials(account_name, roles)
+
                     # Return success message and update the UI
                     return f"Success: Email account '{account_name}' has been deleted.", *update_account_list()
                 except Exception as e:
+                    # store_settings() may have already mutated the cached Settings before
+                    # raising (e.g. a locked keychain in explicit keyring mode); clear the
+                    # cache so a stale, divergent instance isn't served afterwards. A plain
+                    # reload isn't enough — if the reload itself raises too, get_settings()
+                    # would keep the old divergent instance.
+                    clear_settings_cache()
                     return f"Error: {e!s}", *update_account_list()
 
             # Connect the delete button to the delete function
@@ -311,6 +347,11 @@ def create_ui():  # noqa: C901
                         "",  # Clear smtp_password
                     )
                 except Exception as e:
+                    # store_settings() may have already mutated the cached Settings before
+                    # raising; clear it so a divergent instance isn't served afterwards (a
+                    # plain reload isn't enough if the reload itself also raises).
+                    clear_settings_cache()
+
                     # Get account list update
                     account_md, account_choices, btn_visible = update_account_list()
                     return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,13 @@ dependencies = [
     "beautifulsoup4>=4.14.3",
     "gradio>=6.0.1",
     "jinja2>=3.1.5",
+    "keyring>=25.0",
     "loguru>=0.7.3",
     "mcp[cli]>=1.23.0,<2",
     "pydantic>=2.11.0",
     "pydantic-settings[toml]>=2.11.0",
     "tomli-w>=1.2.0",
+    "tomli>=2.0.1; python_version < '3.11'",
     "typer>=0.15.1",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,25 @@ import os
 
 os.environ["MCP_EMAIL_SERVER_CONFIG_PATH"] = (_HERE / "config.toml").as_posix()
 os.environ["MCP_EMAIL_SERVER_LOG_LEVEL"] = "DEBUG"
+# Guardrail: no test may reach a real OS keyring or hang CI waiting on D-Bus. Set at
+# *import time* (not via an autouse fixture) because the existing autouse patch_env
+# fixture below calls delete_settings() before every test, pytest does not guarantee
+# ordering between independent same-scope autouse fixtures, and delete_settings()
+# performs best-effort keyring cleanup — a fixture-based guard could apply too late.
+# Individual tests override this via monkeypatch.setenv(...).
+os.environ["MCP_EMAIL_SERVER_CREDENTIAL_STORAGE"] = "plaintext"
 
 import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
+import keyring
 import pytest
+from keyring.backend import KeyringBackend
+from keyring.backends.fail import Keyring as FailKeyring
+from keyring.errors import PasswordDeleteError
 
+from mcp_email_server import keyring_store
 from mcp_email_server.config import EmailServer, EmailSettings, ProviderSettings, delete_settings
 
 
@@ -107,3 +119,65 @@ def sample_email_data():
         "date": now,
         "attachments": ["attachment.pdf"],
     }
+
+
+class _RecordingKeyring(KeyringBackend):
+    """In-memory keyring that records every get/set/delete call for assertions."""
+
+    priority = 1
+
+    def __init__(self):
+        super().__init__()
+        self._store: dict[tuple[str, str], str] = {}
+        self.calls: list[tuple[str, str, str]] = []
+
+    def set_password(self, service, username, password):
+        self.calls.append(("set", service, username))
+        self._store[(service, username)] = password
+
+    def get_password(self, service, username):
+        self.calls.append(("get", service, username))
+        return self._store.get((service, username))
+
+    def delete_password(self, service, username):
+        self.calls.append(("delete", service, username))
+        key = (service, username)
+        if key not in self._store:
+            raise PasswordDeleteError(f"No such password for service '{service}', username '{username}'")
+        del self._store[key]
+
+
+@pytest.fixture
+def fake_keyring():
+    """Installs an in-memory keyring backend and yields it (with a `.calls` log).
+
+    Backend install is decoupled from credential_storage mode selection — pick the
+    mode a test needs separately via monkeypatch.setenv(...).
+    """
+    previous = keyring.get_keyring()
+    backend = _RecordingKeyring()
+    keyring.set_keyring(backend)
+    keyring_store.keyring_usable.cache_clear()
+    try:
+        yield backend
+    finally:
+        keyring.set_keyring(previous)
+        keyring_store.keyring_usable.cache_clear()
+
+
+@pytest.fixture
+def broken_keyring():
+    """Installs a backend that raises NoKeyringError on every operation.
+
+    Used both to exercise designed failure paths and as a no-I/O tripwire: any
+    accidental keyring call in a test that shouldn't make one raises immediately.
+    """
+    previous = keyring.get_keyring()
+    backend = FailKeyring()
+    keyring.set_keyring(backend)
+    keyring_store.keyring_usable.cache_clear()
+    try:
+        yield backend
+    finally:
+        keyring.set_keyring(previous)
+        keyring_store.keyring_usable.cache_clear()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from mcp_email_server.config import (
     EmailServer,
     EmailSettings,
     ProviderSettings,
+    Settings,
     get_settings,
     normalize_address,
     sender_allowed,
@@ -146,6 +147,157 @@ def test_config():
                 ),
             )
         )
+
+
+def test_add_provider_appends_to_providers():
+    # A bare, uncached Settings() instance — not get_settings() — so this test
+    # can't be affected by, or leak state into, other tests via the module cache.
+    settings = Settings()
+    assert settings.providers == []
+    settings.add_provider(ProviderSettings(account_name="new_provider", provider_name="openai", api_key="sk-test"))
+    assert len(settings.providers) == 1
+    assert settings.providers[0].account_name == "new_provider"
+
+
+def test_duplicate_provider_account_name_rejected():
+    settings = Settings()
+    settings.add_provider(ProviderSettings(account_name="dup_provider", provider_name="a", api_key="k1"))
+    with pytest.raises(ValidationError, match="Duplicate account name"):
+        settings.add_provider(ProviderSettings(account_name="dup_provider", provider_name="b", api_key="k2"))
+
+
+def test_delete_email_and_delete_provider():
+    settings = Settings()
+    settings.add_email(
+        EmailSettings(
+            account_name="to_delete_email",
+            full_name="Test",
+            email_address="del@example.com",
+            incoming=EmailServer(user_name="u", password="p", host="imap.example.com", port=993),
+        )
+    )
+    settings.add_provider(ProviderSettings(account_name="to_delete_provider", provider_name="p", api_key="k"))
+
+    settings.delete_email("to_delete_email")
+    settings.delete_provider("to_delete_provider")
+
+    assert "to_delete_email" not in [e.account_name for e in settings.emails]
+    assert "to_delete_provider" not in [p.account_name for p in settings.providers]
+
+
+def test_get_account_and_get_accounts():
+    settings = Settings()
+    settings.add_email(
+        EmailSettings(
+            account_name="lookup_email",
+            full_name="Test",
+            email_address="lookup@example.com",
+            incoming=EmailServer(user_name="u", password="secret_pw", host="imap.example.com", port=993),
+        )
+    )
+    settings.add_provider(ProviderSettings(account_name="lookup_provider", provider_name="p", api_key="secret_key"))
+
+    email = settings.get_account("lookup_email")
+    assert email.incoming.password.get_secret_value() == "secret_pw"
+
+    masked_email = settings.get_account("lookup_email", masked=True)
+    assert masked_email.incoming.password.get_secret_value() == "********"
+
+    provider = settings.get_account("lookup_provider")
+    assert provider.api_key.get_secret_value() == "secret_key"
+
+    assert settings.get_account("does_not_exist") is None
+
+    all_accounts = settings.get_accounts()
+    assert any(a.account_name == "lookup_email" for a in all_accounts)
+    assert any(a.account_name == "lookup_provider" for a in all_accounts)
+
+    masked_accounts = settings.get_accounts(masked=True)
+    provider_masked = next(a for a in masked_accounts if a.account_name == "lookup_provider")
+    assert provider_masked.api_key.get_secret_value() == "********"
+
+
+def test_store_settings_defaults_to_cached_instance(tmp_path, monkeypatch):
+    """store_settings() with no argument must fetch and store the cached Settings."""
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        config_module.get_settings().add_email(
+            EmailSettings(
+                account_name="no_arg_store",
+                full_name="Test",
+                email_address="a@example.com",
+                incoming=EmailServer(user_name="u", password="p", host="imap.example.com", port=993),
+            )
+        )
+        store_settings()  # no argument
+        assert "no_arg_store" in cfg.read_text()
+    finally:
+        config_module._settings = None
+
+
+def test_env_account_replaces_second_of_multiple_toml_accounts(tmp_path, monkeypatch):
+    """The env-account-injection loop must find a match beyond the first TOML entry."""
+    import tomli_w
+
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    raw = {
+        "emails": [
+            {
+                "account_name": "first",
+                "full_name": "First",
+                "email_address": "first@example.com",
+                "incoming": {
+                    "user_name": "first",
+                    "password": "first_pw",
+                    "host": "imap.first.com",
+                    "port": 993,
+                    "use_ssl": True,
+                    "start_ssl": False,
+                    "verify_ssl": True,
+                },
+            },
+            {
+                "account_name": "second",
+                "full_name": "Second",
+                "email_address": "second@example.com",
+                "incoming": {
+                    "user_name": "second",
+                    "password": "second_pw",
+                    "host": "imap.second.com",
+                    "port": 993,
+                    "use_ssl": True,
+                    "start_ssl": False,
+                    "verify_ssl": True,
+                },
+            },
+        ]
+    }
+    cfg = tmp_path / "config.toml"
+    cfg.write_bytes(tomli_w.dumps(raw).encode())
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ACCOUNT_NAME", "second")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "env@example.com")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "env_pw")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.env.com")
+
+    config_module._settings = None
+    try:
+        settings = config_module.get_settings(reload=True)
+        assert len(settings.emails) == 2
+        second = next(e for e in settings.emails if e.account_name == "second")
+        assert second.incoming.password.get_secret_value() == "env_pw"
+        first = next(e for e in settings.emails if e.account_name == "first")
+        assert first.incoming.password.get_secret_value() == "first_pw"
+    finally:
+        config_module._settings = None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,6 +306,23 @@ def test_store_tightens_preexisting_permissions(tmp_path, monkeypatch):
         config_module._settings = None
 
 
+def test_store_non_posix_falls_back_to_plain_write(tmp_path, monkeypatch):
+    """On non-POSIX platforms store() writes via write_text (no fd-level permissions)."""
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        settings = config_module.get_settings(reload=True)
+        monkeypatch.setattr(config_module.os, "name", "nt")
+        settings.store()
+        assert cfg.read_text() == settings._to_toml()
+    finally:
+        config_module._settings = None
+
+
 def test_report_blocked_mutations_env_overrides_toml(tmp_path, monkeypatch):
     import tomli_w
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+import stat
+import sys
+
 import pytest
 from pydantic import SecretStr, ValidationError
 
@@ -261,6 +264,44 @@ def test_report_blocked_mutations_from_toml(tmp_path, monkeypatch):
     config_module._settings = None
     try:
         assert config_module.get_settings(reload=True).report_blocked_mutations is True
+    finally:
+        config_module._settings = None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permissions only")
+def test_store_writes_owner_only_permissions(tmp_path, monkeypatch):
+    """The stored config contains cleartext credentials, so it must not be world/group readable."""
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        settings = config_module.get_settings(reload=True)
+        settings.store()
+        mode = stat.S_IMODE(cfg.stat().st_mode)
+        assert mode == 0o600
+    finally:
+        config_module._settings = None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permissions only")
+def test_store_tightens_preexisting_permissions(tmp_path, monkeypatch):
+    """A pre-existing world-readable file must be tightened, not left as-is."""
+    import mcp_email_server.config as config_module
+    from mcp_email_server.config import Settings
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("")
+    cfg.chmod(0o644)
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    config_module._settings = None
+    try:
+        settings = config_module.get_settings(reload=True)
+        settings.store()
+        mode = stat.S_IMODE(cfg.stat().st_mode)
+        assert mode == 0o600
     finally:
         config_module._settings = None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -269,19 +269,39 @@ def test_report_blocked_mutations_from_toml(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file permissions only")
-def test_store_writes_owner_only_permissions(tmp_path, monkeypatch):
-    """The stored config contains cleartext credentials, so it must not be world/group readable."""
+@pytest.mark.parametrize("storage_mode", ["plaintext", "keyring"])
+def test_store_writes_owner_only_permissions(tmp_path, monkeypatch, request, storage_mode):
+    """The stored config must not be world/group readable, whether it holds cleartext or sentinels."""
     import mcp_email_server.config as config_module
-    from mcp_email_server.config import Settings
+    from mcp_email_server.config import EmailSettings, Settings
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", storage_mode)
+    if storage_mode == "keyring":
+        # The keyring branch needs a real backend, and an empty Settings has no
+        # secrets to push to it — add an account so a sentinel is actually written.
+        request.getfixturevalue("fake_keyring")
 
     cfg = tmp_path / "config.toml"
     monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
     config_module._settings = None
     try:
         settings = config_module.get_settings(reload=True)
+        if storage_mode == "keyring":
+            settings.add_email(
+                EmailSettings.init(
+                    account_name="acct1",
+                    full_name="Test",
+                    email_address="a@example.com",
+                    user_name="a",
+                    password="hunter2",
+                    imap_host="imap.example.com",
+                )
+            )
         settings.store()
         mode = stat.S_IMODE(cfg.stat().st_mode)
         assert mode == 0o600
+        if storage_mode == "keyring":
+            assert "__KEYRING__" in cfg.read_text()
     finally:
         config_module._settings = None
 

--- a/tests/test_keyring_store.py
+++ b/tests/test_keyring_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import pytest
 import tomli_w
+from keyring.backend import KeyringBackend
 from loguru import logger as loguru_logger
 from pydantic import SecretStr
 from typer.testing import CliRunner
@@ -51,7 +52,8 @@ def _raw_email_toml(account_name: str, password: str, *, host: str = "imap.examp
     }
 
 
-# 1. Round-trip [mode=keyring, fake]
+# 1. Round-trip [mode=keyring, fake] — covers both EmailSettings (incoming+outgoing)
+# and ProviderSettings (api_key) keyring paths.
 def test_round_trip_keyring_mode(tmp_path, monkeypatch, fake_keyring):
     monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "keyring")
     cfg = _bind(tmp_path, monkeypatch)
@@ -69,20 +71,190 @@ def test_round_trip_keyring_mode(tmp_path, monkeypatch, fake_keyring):
             smtp_password="smtp-secret",
         )
     )
+    settings.add_provider(ProviderSettings(account_name="prov1", provider_name="openai", api_key="sk-secret"))
     settings.store()
 
     content = cfg.read_text()
     assert SENTINEL in content
     assert "hunter2" not in content
     assert "smtp-secret" not in content
+    assert "sk-secret" not in content
 
     config_module._settings = None
     reloaded = Settings()
     assert reloaded == settings
     assert isinstance(reloaded.emails[0].incoming.password, SecretStr)
     assert isinstance(reloaded.emails[0].outgoing.password, SecretStr)
+    assert isinstance(reloaded.providers[0].api_key, SecretStr)
     assert reloaded.emails[0].incoming.password.get_secret_value() == "hunter2"
     assert reloaded.emails[0].outgoing.password.get_secret_value() == "smtp-secret"
+    assert reloaded.providers[0].api_key.get_secret_value() == "sk-secret"
+
+
+# Partial keyring failure in auto mode: the probe succeeds (so use_keyring starts
+# True), but the actual account's set_password call fails — distinct from
+# test_auto_mode_falls_back_to_plaintext_on_broken_backend, where the probe itself
+# fails and use_keyring is False from the start.
+class _ProbeOnlyKeyring(KeyringBackend):
+    """Succeeds for the probe's own key, fails for every real account key."""
+
+    priority = 1
+
+    def __init__(self):
+        super().__init__()
+        self._probe_store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, username, password):
+        if username.startswith("__probe__"):
+            self._probe_store[(service, username)] = password
+            return
+        from keyring.errors import PasswordSetError
+
+        raise PasswordSetError("simulated failure storing a real credential")
+
+    def get_password(self, service, username):
+        return self._probe_store.get((service, username))
+
+    def delete_password(self, service, username):
+        key = (service, username)
+        if key in self._probe_store:
+            del self._probe_store[key]
+
+
+def test_auto_mode_falls_back_to_plaintext_on_partial_keyring_failure(tmp_path, monkeypatch):
+    import keyring
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "auto")
+    cfg = _bind(tmp_path, monkeypatch)
+
+    previous = keyring.get_keyring()
+    keyring.set_keyring(_ProbeOnlyKeyring())
+    keyring_store.keyring_usable.cache_clear()
+    try:
+        settings = Settings()
+        settings.add_email(
+            EmailSettings.init(
+                account_name="acct1",
+                full_name="Test",
+                email_address="a@example.com",
+                user_name="a",
+                password="hunter2",
+                imap_host="imap.example.com",
+            )
+        )
+        # A provider account too, so the provider-side set_secret failure branch
+        # (distinct from the email-side one) is also exercised.
+        settings.add_provider(ProviderSettings(account_name="prov1", provider_name="openai", api_key="sk-secret"))
+
+        messages: list[str] = []
+        sink_id = loguru_logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+        try:
+            settings.store()  # must not raise despite the probe reporting "usable"
+        finally:
+            loguru_logger.remove(sink_id)
+    finally:
+        keyring.set_keyring(previous)
+        keyring_store.keyring_usable.cache_clear()
+
+    content = cfg.read_text()
+    assert "hunter2" in content
+    assert "sk-secret" in content
+    assert SENTINEL not in content
+    assert any("falling back to plaintext" in m for m in messages)
+
+
+# auto mode with a genuinely usable backend must actually use it (exercises the
+# keyring_usable() probe's success path, not just its failure path).
+def test_auto_mode_uses_keyring_when_backend_usable(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "auto")
+    cfg = _bind(tmp_path, monkeypatch)
+
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+        )
+    )
+    settings.store()
+
+    content = cfg.read_text()
+    assert SENTINEL in content
+    assert "hunter2" not in content
+    assert fake_keyring._store[(SERVICE, "acct1:incoming")] == "hunter2"
+    # The probe's own set/get/delete round-trip must have happened.
+    assert any(call[0] == "delete" and call[2].startswith("__probe__") for call in fake_keyring.calls)
+
+
+class _WrongValueProbeKeyring(KeyringBackend):
+    """set/get/delete all succeed without raising, but get returns the wrong
+    value for the probe key — usability must be decided by set/get, not just
+    the absence of an exception.
+    """
+
+    priority = 1
+
+    def set_password(self, service, username, password):
+        pass
+
+    def get_password(self, service, username):
+        return "not-ok"
+
+    def delete_password(self, service, username):
+        pass
+
+
+def test_keyring_usable_false_when_probe_value_mismatches_without_raising(monkeypatch):
+    import keyring
+
+    previous = keyring.get_keyring()
+    keyring.set_keyring(_WrongValueProbeKeyring())
+    keyring_store.keyring_usable.cache_clear()
+    try:
+        assert keyring_store.keyring_usable() is False
+    finally:
+        keyring.set_keyring(previous)
+        keyring_store.keyring_usable.cache_clear()
+
+
+class _DeleteFailsProbeKeyring(KeyringBackend):
+    """set/get succeed normally, but delete (the probe's own cleanup) raises —
+    a working backend must not be misclassified as unusable because of this.
+    """
+
+    priority = 1
+
+    def __init__(self):
+        super().__init__()
+        self._store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, username, password):
+        self._store[(service, username)] = password
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def delete_password(self, service, username):
+        from keyring.errors import PasswordDeleteError
+
+        raise PasswordDeleteError("simulated cleanup failure")
+
+
+def test_keyring_usable_true_despite_probe_cleanup_failure(monkeypatch):
+    import keyring
+
+    previous = keyring.get_keyring()
+    keyring.set_keyring(_DeleteFailsProbeKeyring())
+    keyring_store.keyring_usable.cache_clear()
+    try:
+        assert keyring_store.keyring_usable() is True
+    finally:
+        keyring.set_keyring(previous)
+        keyring_store.keyring_usable.cache_clear()
 
 
 # 2. Auto fallback [mode=auto, broken]
@@ -161,6 +333,17 @@ def test_missing_keyring_entry_raises_on_load(tmp_path, monkeypatch, fake_keyrin
         Settings()
 
 
+# 4b. get_secret() raising (not just returning None) must also raise on load.
+def test_broken_backend_raises_on_load_when_sentinel_present(tmp_path, monkeypatch, broken_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "keyring")
+    cfg = _bind(tmp_path, monkeypatch)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("acct1", SENTINEL)))
+
+    config_module._settings = None
+    with pytest.raises(ValueError, match="acct1"):
+        Settings()
+
+
 # 5. Mixed file [mode=auto, fake holding the sentinel account's secret]
 def test_mixed_sentinel_and_cleartext_accounts_load(tmp_path, monkeypatch, fake_keyring):
     monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "auto")
@@ -182,8 +365,62 @@ def test_mixed_sentinel_and_cleartext_accounts_load(tmp_path, monkeypatch, fake_
     assert by_name["acct2"].incoming.password.get_secret_value() == "cleartext2"
 
 
-# 6. Migration both directions [fake; env override unset]
+# 6. Migration both directions [fake; env override unset]. Uses an account with
+# both incoming+outgoing plus a provider, so the --to plaintext cleanup loop
+# exercises both the outgoing-role branch and the provider branch.
 def test_migration_round_trip_both_directions(tmp_path, monkeypatch, fake_keyring):
+    cfg = _bind(tmp_path, monkeypatch, also_config_path=True)
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "plaintext")
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+            smtp_password="smtp-secret",
+        )
+    )
+    settings.add_provider(ProviderSettings(account_name="prov1", provider_name="openai", api_key="sk-secret"))
+    settings.store()
+    assert "hunter2" in cfg.read_text()
+    assert "sk-secret" in cfg.read_text()
+
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["migrate-credentials", "--to", "keyring"])
+    assert result.exit_code == 0, result.output
+
+    content = cfg.read_text()
+    assert SENTINEL in content
+    assert "hunter2" not in content
+    assert "smtp-secret" not in content
+    assert "sk-secret" not in content
+    assert 'credential_storage = "keyring"' in content
+    assert fake_keyring._store[(SERVICE, "acct1:incoming")] == "hunter2"
+    assert fake_keyring._store[(SERVICE, "acct1:outgoing")] == "smtp-secret"
+    assert fake_keyring._store[(SERVICE, "prov1:api_key")] == "sk-secret"
+
+    result2 = runner.invoke(cli_app, ["migrate-credentials", "--to", "plaintext"])
+    assert result2.exit_code == 0, result2.output
+
+    content2 = cfg.read_text()
+    assert "hunter2" in content2
+    assert "smtp-secret" in content2
+    assert "sk-secret" in content2
+    assert SENTINEL not in content2
+    assert 'credential_storage = "plaintext"' in content2
+    assert (SERVICE, "acct1:incoming") not in fake_keyring._store
+    assert (SERVICE, "acct1:outgoing") not in fake_keyring._store
+    assert (SERVICE, "prov1:api_key") not in fake_keyring._store
+
+
+def test_migrate_credentials_warns_on_env_override_conflict(tmp_path, monkeypatch, fake_keyring):
     cfg = _bind(tmp_path, monkeypatch, also_config_path=True)
 
     monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "plaintext")
@@ -201,26 +438,73 @@ def test_migration_round_trip_both_directions(tmp_path, monkeypatch, fake_keyrin
     settings.store()
     assert "hunter2" in cfg.read_text()
 
-    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
-
+    # Deliberately conflicting: env says "plaintext", --to says "keyring".
     runner = CliRunner()
     result = runner.invoke(cli_app, ["migrate-credentials", "--to", "keyring"])
     assert result.exit_code == 0, result.output
+    assert "MCP_EMAIL_SERVER_CREDENTIAL_STORAGE" in result.output
+    assert "differs" in result.output
+
+
+def test_migrate_credentials_to_plaintext_skips_outgoing_cleanup_for_incoming_only_account(
+    tmp_path, monkeypatch, fake_keyring
+):
+    """The --to plaintext cleanup loop's outgoing-role branch must be skipped
+    (not attempted) for an account that never had outgoing configured.
+    """
+    cfg = _bind(tmp_path, monkeypatch, also_config_path=True)
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+        )
+    )
+    settings.add_provider(ProviderSettings(account_name="prov1", provider_name="openai", api_key="sk-secret"))
+    settings.credential_storage = "keyring"
+    settings._credential_storage_override = "keyring"
+    settings.store()
+    assert cfg.read_text().count(SENTINEL) == 2  # incoming password + api_key, no outgoing
+
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["migrate-credentials", "--to", "plaintext"])
+    assert result.exit_code == 0, result.output
 
     content = cfg.read_text()
-    assert SENTINEL in content
-    assert "hunter2" not in content
-    assert 'credential_storage = "keyring"' in content
-    assert fake_keyring._store[(SERVICE, "acct1:incoming")] == "hunter2"
-
-    result2 = runner.invoke(cli_app, ["migrate-credentials", "--to", "plaintext"])
-    assert result2.exit_code == 0, result2.output
-
-    content2 = cfg.read_text()
-    assert "hunter2" in content2
-    assert SENTINEL not in content2
-    assert 'credential_storage = "plaintext"' in content2
+    assert "hunter2" in content
+    assert "sk-secret" in content
     assert (SERVICE, "acct1:incoming") not in fake_keyring._store
+    assert (SERVICE, "prov1:api_key") not in fake_keyring._store
+    assert (SERVICE, "acct1:outgoing") not in fake_keyring._store  # never existed; delete is a no-op
+
+
+def test_migrate_credentials_load_failure_exits_cleanly(tmp_path, monkeypatch, broken_keyring):
+    cfg = _bind(tmp_path, monkeypatch, also_config_path=True)
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("acct1", SENTINEL)))
+
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["migrate-credentials", "--to", "plaintext"])
+    assert result.exit_code == 1
+    assert "could not load" in result.output
+    assert not isinstance(result.exception, ValueError)  # typer.Exit, not a raw traceback
+
+
+def test_migrate_credentials_store_failure_exits_cleanly(tmp_path, monkeypatch, broken_keyring):
+    cfg = _bind(tmp_path, monkeypatch, also_config_path=True)
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("acct1", "cleartext")))
+
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["migrate-credentials", "--to", "keyring"])
+    assert result.exit_code == 1
+    assert "failed" in result.output
 
 
 # 6b. Migration ignores env-account shadowing (flag (c), §7)
@@ -313,6 +597,45 @@ def test_reset_mode_gate_attempts_cleanup_when_toml_mode_is_not_plaintext(tmp_pa
     assert not cfg.exists()
     assert (SERVICE, "acct1:incoming") not in fake_keyring._store
     assert any(call[0] == "delete" for call in fake_keyring.calls)
+
+
+def test_reset_cleans_up_outgoing_role_provider_and_skips_malformed_entries(tmp_path, monkeypatch, fake_keyring):
+    """Covers the reset cleanup's outgoing-role branch, provider loop, and the
+    defensive skip for an email entry with no account_name.
+    """
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+
+    fake_keyring.set_password(SERVICE, "acct1:incoming", "secret1")
+    fake_keyring.set_password(SERVICE, "acct1:outgoing", "secret2")
+    fake_keyring.set_password(SERVICE, "prov1:api_key", "secret3")
+
+    raw = _raw_email_toml("acct1", SENTINEL)
+    raw["emails"][0]["outgoing"] = dict(raw["emails"][0]["incoming"], password=SENTINEL)
+    raw["emails"].append({"full_name": "No account name", "email_address": "x@example.com"})  # malformed
+    raw["providers"] = [
+        {"account_name": "prov1", "provider_name": "openai", "api_key": SENTINEL},
+        {"provider_name": "no-name-provider", "api_key": SENTINEL},  # malformed: no account_name
+    ]
+    raw["credential_storage"] = "keyring"
+    cfg.write_text(tomli_w.dumps(raw))
+
+    delete_settings()  # must not raise despite the malformed email/provider entries
+    assert not cfg.exists()
+    assert (SERVICE, "acct1:incoming") not in fake_keyring._store
+    assert (SERVICE, "acct1:outgoing") not in fake_keyring._store
+    assert (SERVICE, "prov1:api_key") not in fake_keyring._store
+
+
+def test_reset_unparseable_toml_still_unlinks(tmp_path, monkeypatch):
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+    cfg.write_text("this is not [ valid toml =::")
+
+    delete_settings()  # must not raise; warns and unlinks anyway
+    assert not cfg.exists()
 
 
 # 8. Sentinel value rejected everywhere

--- a/tests/test_keyring_store.py
+++ b/tests/test_keyring_store.py
@@ -1,0 +1,400 @@
+"""Tests for OS keyring credential storage (plan: keyring-credential-storage).
+
+Every test picks its credential_storage mode explicitly via monkeypatch.setenv —
+the conftest.py import-time default is "plaintext" so nothing here runs vacuously
+under that default (see conftest.py's guardrail comment).
+"""
+
+from __future__ import annotations
+
+import pytest
+import tomli_w
+from loguru import logger as loguru_logger
+from pydantic import SecretStr
+from typer.testing import CliRunner
+
+import mcp_email_server.config as config_module
+from mcp_email_server import keyring_store
+from mcp_email_server.cli import app as cli_app
+from mcp_email_server.config import EmailServer, EmailSettings, ProviderSettings, Settings, delete_settings
+from mcp_email_server.keyring_store import SENTINEL, SERVICE
+
+
+def _bind(tmp_path, monkeypatch, *, also_config_path: bool = False):
+    """Point Settings' toml_file (and optionally CONFIG_PATH) at a fresh temp file."""
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+    if also_config_path:
+        monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+    config_module._settings = None
+    return cfg
+
+
+def _raw_email_toml(account_name: str, password: str, *, host: str = "imap.example.com") -> dict:
+    return {
+        "emails": [
+            {
+                "account_name": account_name,
+                "full_name": "Test",
+                "email_address": f"{account_name}@example.com",
+                "incoming": {
+                    "user_name": account_name,
+                    "password": password,
+                    "host": host,
+                    "port": 993,
+                    "use_ssl": True,
+                    "start_ssl": False,
+                    "verify_ssl": True,
+                },
+            }
+        ]
+    }
+
+
+# 1. Round-trip [mode=keyring, fake]
+def test_round_trip_keyring_mode(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "keyring")
+    cfg = _bind(tmp_path, monkeypatch)
+
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+            smtp_host="smtp.example.com",
+            smtp_password="smtp-secret",
+        )
+    )
+    settings.store()
+
+    content = cfg.read_text()
+    assert SENTINEL in content
+    assert "hunter2" not in content
+    assert "smtp-secret" not in content
+
+    config_module._settings = None
+    reloaded = Settings()
+    assert reloaded == settings
+    assert isinstance(reloaded.emails[0].incoming.password, SecretStr)
+    assert isinstance(reloaded.emails[0].outgoing.password, SecretStr)
+    assert reloaded.emails[0].incoming.password.get_secret_value() == "hunter2"
+    assert reloaded.emails[0].outgoing.password.get_secret_value() == "smtp-secret"
+
+
+# 2. Auto fallback [mode=auto, broken]
+def test_auto_mode_falls_back_to_plaintext_on_broken_backend(tmp_path, monkeypatch, broken_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "auto")
+    cfg = _bind(tmp_path, monkeypatch)
+
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+        )
+    )
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    try:
+        settings.store()  # must not raise
+    finally:
+        loguru_logger.remove(sink_id)
+
+    content = cfg.read_text()
+    assert "hunter2" in content
+    assert SENTINEL not in content
+    assert any("plaintext" in m and "keyring" in m for m in messages)
+
+
+# 3. Explicit keyring, no backend [mode=keyring, broken]
+def test_explicit_keyring_mode_raises_without_usable_backend(tmp_path, monkeypatch, broken_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "keyring")
+    cfg = _bind(tmp_path, monkeypatch)
+
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+        )
+    )
+    with pytest.raises(ValueError, match="keyring"):
+        settings.store()
+    assert not cfg.exists()
+
+
+# 4. Missing entry [mode=keyring, fake with the entry deleted]
+def test_missing_keyring_entry_raises_on_load(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "keyring")
+    _bind(tmp_path, monkeypatch)
+
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+        )
+    )
+    settings.store()
+
+    fake_keyring._store.clear()  # simulate the entry vanishing from the keyring
+
+    config_module._settings = None
+    with pytest.raises(ValueError, match="acct1"):
+        Settings()
+
+
+# 5. Mixed file [mode=auto, fake holding the sentinel account's secret]
+def test_mixed_sentinel_and_cleartext_accounts_load(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "auto")
+    cfg = _bind(tmp_path, monkeypatch)
+
+    fake_keyring.set_password(SERVICE, "acct1:incoming", "secret1")
+    raw = {
+        "emails": [
+            _raw_email_toml("acct1", SENTINEL, host="imap1.example.com")["emails"][0],
+            _raw_email_toml("acct2", "cleartext2", host="imap2.example.com")["emails"][0],
+        ]
+    }
+    cfg.write_text(tomli_w.dumps(raw))
+
+    config_module._settings = None
+    settings = Settings()
+    by_name = {e.account_name: e for e in settings.emails}
+    assert by_name["acct1"].incoming.password.get_secret_value() == "secret1"
+    assert by_name["acct2"].incoming.password.get_secret_value() == "cleartext2"
+
+
+# 6. Migration both directions [fake; env override unset]
+def test_migration_round_trip_both_directions(tmp_path, monkeypatch, fake_keyring):
+    cfg = _bind(tmp_path, monkeypatch, also_config_path=True)
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "plaintext")
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="acct1",
+            full_name="Test",
+            email_address="a@example.com",
+            user_name="a",
+            password="hunter2",
+            imap_host="imap.example.com",
+        )
+    )
+    settings.store()
+    assert "hunter2" in cfg.read_text()
+
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_app, ["migrate-credentials", "--to", "keyring"])
+    assert result.exit_code == 0, result.output
+
+    content = cfg.read_text()
+    assert SENTINEL in content
+    assert "hunter2" not in content
+    assert 'credential_storage = "keyring"' in content
+    assert fake_keyring._store[(SERVICE, "acct1:incoming")] == "hunter2"
+
+    result2 = runner.invoke(cli_app, ["migrate-credentials", "--to", "plaintext"])
+    assert result2.exit_code == 0, result2.output
+
+    content2 = cfg.read_text()
+    assert "hunter2" in content2
+    assert SENTINEL not in content2
+    assert 'credential_storage = "plaintext"' in content2
+    assert (SERVICE, "acct1:incoming") not in fake_keyring._store
+
+
+# 6b. Migration ignores env-account shadowing (flag (c), §7)
+def test_migration_ignores_env_account_shadow(tmp_path, monkeypatch, fake_keyring):
+    _bind(tmp_path, monkeypatch)
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "plaintext")
+    settings = Settings()
+    settings.add_email(
+        EmailSettings.init(
+            account_name="default",
+            full_name="Stored",
+            email_address="stored@example.com",
+            user_name="stored",
+            password="stored-secret",
+            imap_host="imap.stored.example.com",
+        )
+    )
+    settings.store()
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+
+    # These would normally inject/override an EmailSettings for account "default".
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ACCOUNT_NAME", "default")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "env@example.com")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "env-secret")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.env.example.com")
+
+    migrated = Settings.load_for_migration()
+    assert migrated.emails[0].incoming.password.get_secret_value() == "stored-secret"
+    assert migrated.emails[0].incoming.host == "imap.stored.example.com"
+
+
+# 7. Deletion cleanup. ui.py is excluded from this project's coverage/unit tests
+# (pyproject.toml omits it), so the gating contract ("skip keyring entirely when
+# effective mode is plaintext") is exercised here via the equally-gated
+# delete_settings() reset path, plus direct tests of the shared keyring_store
+# helper both flows call.
+def test_delete_account_credentials_removes_entries(fake_keyring):
+    fake_keyring.set_password(SERVICE, "acct1:incoming", "secret1")
+    fake_keyring.set_password(SERVICE, "acct1:outgoing", "secret2")
+    keyring_store.delete_account_credentials("acct1", ["incoming", "outgoing"])
+    assert (SERVICE, "acct1:incoming") not in fake_keyring._store
+    assert (SERVICE, "acct1:outgoing") not in fake_keyring._store
+
+
+def test_delete_account_credentials_swallows_broken_backend(broken_keyring):
+    keyring_store.delete_account_credentials("acct1", ["incoming"])  # must not raise
+
+
+def test_reset_performs_zero_keyring_calls_in_plaintext_mode(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "plaintext")
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("acct1", "cleartext")))
+
+    delete_settings()
+    assert not cfg.exists()
+    assert fake_keyring.calls == []
+
+
+# 8. Sentinel value rejected everywhere
+def test_sentinel_value_rejected_at_creation_entry_points():
+    with pytest.raises(ValueError, match="reserved"):
+        EmailSettings.init(
+            account_name="x",
+            full_name="x",
+            email_address="x@example.com",
+            user_name="x",
+            password=SENTINEL,
+            imap_host="imap.example.com",
+        )
+
+    settings = Settings()
+    email = EmailSettings(
+        account_name="x",
+        full_name="x",
+        email_address="x@example.com",
+        incoming=EmailServer(user_name="x", password=SENTINEL, host="imap.example.com", port=993),
+    )
+    with pytest.raises(ValueError, match="reserved"):
+        settings.add_email(email)
+
+    provider = ProviderSettings(account_name="p", provider_name="p", api_key=SENTINEL)
+    with pytest.raises(ValueError, match="reserved"):
+        settings.add_provider(provider)
+
+
+def test_sentinel_value_rejected_at_store_pre_write_check():
+    settings = Settings()
+    email = EmailSettings(
+        account_name="x",
+        full_name="x",
+        email_address="x@example.com",
+        incoming=EmailServer(user_name="x", password=SENTINEL, host="imap.example.com", port=993),
+    )
+    settings.emails.append(email)  # bypasses add_email's guard, same as an existing test pattern
+    with pytest.raises(ValueError, match="reserved"):
+        settings.store()
+
+
+# 10. Env preemption [mode=auto, broken, sentinel TOML + matching env account]
+def test_env_account_preempts_sentinel_resolution(tmp_path, monkeypatch, broken_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "auto")
+    cfg = _bind(tmp_path, monkeypatch)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("default", SENTINEL, host="imap.stored.example.com")))
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ACCOUNT_NAME", "default")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "env@example.com")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "env-secret")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.env.example.com")
+
+    config_module._settings = None
+    settings = Settings()  # would raise if it touched the (broken) keyring at all
+    assert settings.emails[0].incoming.password.get_secret_value() == "env-secret"
+
+
+# 11. Broken-keyring reset [mode=auto, broken, sentinel TOML]
+def test_reset_unlinks_file_despite_broken_keyring(tmp_path, monkeypatch, broken_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "auto")
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("acct1", SENTINEL)))
+    assert cfg.exists()
+
+    delete_settings()  # must not raise despite broken backend + sentinel content
+    assert not cfg.exists()
+
+
+# 12. Plaintext + sentinel file [mode=plaintext, fake installed]
+def test_plaintext_mode_with_sentinel_file_is_hard_error(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "plaintext")
+    cfg = _bind(tmp_path, monkeypatch)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("acct1", SENTINEL)))
+
+    with pytest.raises(ValueError, match="migrate-credentials"):
+        Settings()
+    assert fake_keyring.calls == []
+
+
+# 13. Plaintext + sentinel + matching env account [mode=plaintext, fake installed]
+def test_plaintext_mode_env_account_preempts_sentinel_error(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "plaintext")
+    cfg = _bind(tmp_path, monkeypatch)
+    cfg.write_text(tomli_w.dumps(_raw_email_toml("default", SENTINEL, host="imap.stored.example.com")))
+
+    monkeypatch.setenv("MCP_EMAIL_SERVER_ACCOUNT_NAME", "default")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_EMAIL_ADDRESS", "env@example.com")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_PASSWORD", "env-secret")
+    monkeypatch.setenv("MCP_EMAIL_SERVER_IMAP_HOST", "imap.env.example.com")
+
+    settings = Settings()  # must not raise
+    assert settings.emails[0].incoming.password.get_secret_value() == "env-secret"
+    assert fake_keyring.calls == []
+
+
+# 14. Invalid MCP_EMAIL_SERVER_CREDENTIAL_STORAGE value
+def test_invalid_credential_storage_env_value_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "bogus")
+    _bind(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError) as exc_info:
+        Settings()
+    msg = str(exc_info.value)
+    assert "auto" in msg
+    assert "keyring" in msg
+    assert "plaintext" in msg
+
+
+def test_invalid_credential_storage_env_value_reset_still_unlinks(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.setenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", "bogus")
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+    cfg.write_text(tomli_w.dumps({"emails": []}))
+    assert cfg.exists()
+
+    delete_settings()  # must not raise; warns and proceeds as non-plaintext
+    assert not cfg.exists()

--- a/tests/test_keyring_store.py
+++ b/tests/test_keyring_store.py
@@ -281,6 +281,40 @@ def test_reset_performs_zero_keyring_calls_in_plaintext_mode(tmp_path, monkeypat
     assert fake_keyring.calls == []
 
 
+def test_reset_mode_gate_falls_back_to_raw_toml_key_when_env_unset(tmp_path, monkeypatch, fake_keyring):
+    """With no env override, the reset gate must read credential_storage from the
+    TOML file itself — the real-world default path (no test here previously
+    exercised it, since every other reset test sets the env var explicitly).
+    """
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+
+    raw = _raw_email_toml("acct1", "cleartext")
+    raw["credential_storage"] = "plaintext"
+    cfg.write_text(tomli_w.dumps(raw))
+
+    delete_settings()
+    assert not cfg.exists()
+    assert fake_keyring.calls == []
+
+
+def test_reset_mode_gate_attempts_cleanup_when_toml_mode_is_not_plaintext(tmp_path, monkeypatch, fake_keyring):
+    monkeypatch.delenv("MCP_EMAIL_SERVER_CREDENTIAL_STORAGE", raising=False)
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_PATH", cfg)
+
+    fake_keyring.set_password(SERVICE, "acct1:incoming", "secret1")
+    raw = _raw_email_toml("acct1", SENTINEL)
+    raw["credential_storage"] = "keyring"
+    cfg.write_text(tomli_w.dumps(raw))
+
+    delete_settings()
+    assert not cfg.exists()
+    assert (SERVICE, "acct1:incoming") not in fake_keyring._store
+    assert any(call[0] == "delete" for call in fake_keyring.calls)
+
+
 # 8. Sentinel value rejected everywhere
 def test_sentinel_value_rejected_at_creation_entry_points():
     with pytest.raises(ValueError, match="reserved"):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -117,6 +117,59 @@ class TestMcpTools:
             mock_settings.store.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_add_email_account_duplicate_name_does_not_corrupt_cache(self, tmp_path, monkeypatch):
+        """A rejected duplicate-name add must not leave a mutated account list cached.
+
+        Settings.add_email() reassigns settings.emails, and pydantic's
+        validate_assignment applies the new value BEFORE the
+        check_unique_account_names after-validator raises — so a naive
+        `settings.add_email(email); settings.store()` sequence leaves the cached
+        Settings instance corrupted even though the raise happened before store().
+        """
+        import mcp_email_server.config as config_module
+        from mcp_email_server.config import Settings
+
+        cfg = tmp_path / "config.toml"
+        monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+        config_module._settings = None
+
+        email_settings = EmailSettings(
+            account_name="dup",
+            full_name="Test User",
+            email_address="test@example.com",
+            incoming=EmailServer(user_name="test_user", password="test_password", host="imap.example.com", port=993),
+        )
+        duplicate = EmailSettings(
+            account_name="dup",
+            full_name="Someone Else",
+            email_address="other@example.com",
+            incoming=EmailServer(user_name="other_user", password="other_password", host="imap.other.com", port=993),
+        )
+
+        try:
+            await add_email_account(email_settings)
+
+            with pytest.raises(Exception, match="Duplicate account name"):
+                await add_email_account(duplicate)
+
+            # The cache must have been discarded, not left holding two "dup" entries.
+            reloaded = config_module.get_settings()
+            assert [e.account_name for e in reloaded.emails] == ["dup"]
+
+            # A subsequent, non-conflicting add must succeed rather than tripping
+            # over a corrupted duplicate that was never actually persisted.
+            new_account = EmailSettings(
+                account_name="brand_new",
+                full_name="New User",
+                email_address="new@example.com",
+                incoming=EmailServer(user_name="new_user", password="new_password", host="imap.new.com", port=993),
+            )
+            result = await add_email_account(new_account)
+            assert result == "Successfully added email account 'brand_new'"
+        finally:
+            config_module._settings = None
+
+    @pytest.mark.asyncio
     async def test_list_emails_metadata(self):
         """Test list_emails_metadata MCP tool."""
         # Create test data

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "backrefs"
 version = "5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -638,7 +647,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -874,12 +883,69 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -919,6 +985,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1081,10 +1165,12 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "gradio" },
     { name = "jinja2" },
+    { name = "keyring" },
     { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "pydantic-settings", extra = ["toml"] },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomli-w" },
     { name = "typer" },
 ]
@@ -1110,10 +1196,12 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "gradio", specifier = ">=6.0.1" },
     { name = "jinja2", specifier = ">=3.1.5" },
+    { name = "keyring", specifier = ">=25.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0,<2" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-settings", extras = ["toml"], specifier = ">=2.11.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
@@ -1268,6 +1356,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/ae/58ab2bfbee2792e92a98b97e872f7c003deb903071f75d8d83aa55db28fa/mkdocstrings_python-1.18.2.tar.gz", hash = "sha256:4ad536920a07b6336f50d4c6d5603316fafb1172c5c882370cbbc954770ad323", size = 207972, upload-time = "2025-08-28T16:11:19.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/8f/ce008599d9adebf33ed144e7736914385e8537f5fc686fdb7cceb8c22431/mkdocstrings_python-1.18.2-py3-none-any.whl", hash = "sha256:944fe6deb8f08f33fa936d538233c4036e9f53e840994f6146e8e94eb71b600d", size = 138215, upload-time = "2025-08-28T16:11:18.176Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -2059,6 +2156,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2359,6 +2465,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/d1/4282284d9cf1ee873607a46442da977fc3c985059315ab23610be31d5885/safehttpx-0.1.7.tar.gz", hash = "sha256:db201c0978c41eddb8bb480f3eee59dd67304fdd91646035e9d9a720049a9d23", size = 10385, upload-time = "2025-10-24T18:30:09.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl", hash = "sha256:c4f4a162db6993464d7ca3d7cc4af0ffc6515a606dfd220b9f82c6945d869cde", size = 8959, upload-time = "2025-10-24T18:30:08.733Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -2685,4 +2804,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #195.** This branch is built on top of `fix/restrict-credentials-file-permissions` (#195), which is still open. Until #195 merges, this diff includes its commits too — please review/merge #195 first, then this PR's diff will automatically shrink to just the commits below. Do not merge this before #195.

## Summary

Adds OS keyring credential storage for IMAP/SMTP passwords and provider API keys, with automatic fallback to the existing plaintext TOML file (`0o600`, from #195) when no usable keyring backend is available (headless Linux, Docker, no D-Bus session).

- New `credential_storage` setting (`auto` / `keyring` / `plaintext`, default `auto`), overridable via `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`.
- `auto` probes the OS keyring (macOS Keychain, Linux Secret Service) with a real set/get round-trip at store time only — never on load, never at import — and falls back to plaintext if unusable.
- Keyring-backed secrets are stored under service `mcp-email-server`, one entry per `<account_name>:<incoming|outgoing|api_key>`; the TOML file keeps only a `__KEYRING__` placeholder and non-secret metadata.
- New `mcp-email-server migrate-credentials --to keyring|plaintext` CLI command to move an existing config between modes; migration loads bypass env-composited state (env accounts, allowlist/bool env overrides) so it transforms the *stored* config, not a temporarily-overridden view.
- Cache-divergence handling: if a store fails partway (e.g. a locked keychain in explicit `keyring` mode) after the in-memory `Settings` was already mutated, the cached singleton is discarded rather than served stale — covers the `add_email_account` MCP tool and both Gradio UI handlers (save + delete).
- README: new "Credential Storage" section with modes, migration command, and a failure-modes/troubleshooting subsection (locked keychain at boot, macOS per-app Keychain ACL prompts under `uvx`, plaintext+sentinel hard error).

### Design process

This was planned with [`/plan-adversial`](plans/keyring-credential-storage.md) — 7 rounds of independent adversarial review resolving 47 findings before implementation started — then implemented and adversarially code-reviewed after, which caught and fixed one real bug: `add_email_account` could corrupt the cached `Settings` singleton on a duplicate-account-name error (pydantic's `validate_assignment` applies a reassigned list *before* the uniqueness validator raises), blocking all future account additions until restart. Fixed in the second commit with a regression test.

## Test plan

- [x] `uv run pytest -q` — 471 passed (up from 448 on `main`, +23 new/extended: keyring round-trip, auto-fallback, explicit-mode failure, missing-entry, mixed sentinel/cleartext, migration both directions incl. env-account isolation, deletion cleanup incl. mode-gating, sentinel rejection at all 4 enforcement points, permissions in both modes, env-preemption, broken-keyring reset, plaintext+sentinel hard error, invalid env value, and the cache-corruption regression test)
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run deptry .` — clean
- [x] Test guardrail: `tests/conftest.py` pins `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE=plaintext` at import time so the suite never touches a real OS keyring or hangs CI on D-Bus; tests that need keyring behavior opt in via `fake_keyring`/`broken_keyring` fixtures
- [ ] Manual smoke on macOS (add account → Keychain Access entry, `uvx` ACL prompt path, migrate both directions) — not yet run in this environment
- [ ] Manual smoke in Docker/headless Linux — not yet run in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)