### PR TITLE
fix(ui): don't require SMTP host when adding an email account

### DIFF
--- a/mcp_email_server/ui.py
+++ b/mcp_email_server/ui.py
@@ -137,7 +137,7 @@ def create_ui():  # noqa: C901
                     gr.Markdown("### SMTP Settings")
                     smtp_host = gr.Textbox(
                         label="SMTP Host (optional)",
-                        placeholder="e.g. smtp.example.com — leave empty for a read-only IMAP account",
+                        placeholder="e.g. smtp.example.com — leave empty for an IMAP-only account",
                     )
                     smtp_port = gr.Number(label="SMTP Port", value=465)
                     smtp_ssl = gr.Checkbox(label="Use SSL", value=True)

--- a/mcp_email_server/ui.py
+++ b/mcp_email_server/ui.py
@@ -135,7 +135,10 @@ def create_ui():  # noqa: C901
                 # SMTP settings
                 with gr.Column():
                     gr.Markdown("### SMTP Settings")
-                    smtp_host = gr.Textbox(label="SMTP Host", placeholder="e.g. smtp.example.com")
+                    smtp_host = gr.Textbox(
+                        label="SMTP Host (optional)",
+                        placeholder="e.g. smtp.example.com — leave empty for a read-only IMAP account",
+                    )
                     smtp_port = gr.Number(label="SMTP Port", value=465)
                     smtp_ssl = gr.Checkbox(label="Use SSL", value=True)
                     smtp_start_ssl = gr.Checkbox(label="Start SSL", value=False)
@@ -201,11 +204,11 @@ def create_ui():  # noqa: C901
                             smtp_password,
                         )
 
-                    if not imap_host or not smtp_host:
+                    if not imap_host:
                         # Get account list update
                         account_md, account_choices, btn_visible = update_account_list()
                         return (
-                            "Error: IMAP and SMTP hosts are required.",
+                            "Error: IMAP host is required.",
                             account_md,
                             account_choices,
                             btn_visible,


### PR DESCRIPTION
## Summary
- The Gradio UI's \`save_email_settings\` unconditionally required both \`imap_host\` and \`smtp_host\`, blocking read-only IMAP-only accounts through the GUI — even though \`EmailSettings.init()\` already supports \`smtp_host=None\`, and the env-var config path already documents this as "Read-only IMAP mode" in the README.
- Now only IMAP host is required; SMTP Host is labeled "(optional)" with an updated placeholder, and leaving it blank produces an account with \`outgoing=None\` as the rest of the app already expects.
- No other change — same validation ordering, same error-return shape.

## Test plan
- [x] Verified live in a running Gradio session (not just unit tests, since \`ui.py\` is excluded from this repo's test/coverage config):
  - Filled the form with SMTP Host blank → saved successfully, TOML has no \`[emails.outgoing]\` block, account list shows only "IMAP Provider" (no "SMTP Provider" line)
  - Filled the form with IMAP Host blank → still correctly rejected with "Error: IMAP host is required."
- [x] \`uv run pytest -q\` — 446 passed (full suite, unrelated to this change)
- [x] \`uv run ruff check\` / \`uv run ruff format --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)